### PR TITLE
stevedore should handle (quote) whitespace arguments

### DIFF
--- a/src/pallet/stevedore.clj
+++ b/src/pallet/stevedore.clj
@@ -613,12 +613,12 @@
     (if argument
       (if (> (.length opt) 1)
         (str dash opt (if-not (= argument true)
-                        (str (if do-assign "=" " ") argument)))
-        (str "-" opt (if-not (= argument true) (str " " argument)))))))
+                        (str (if do-assign "=" " ") \" argument \")))
+        (str "-" opt (if-not (= argument true) (str " " \" argument \")))))))
 
 (defn map-to-arg-string
   "Output a set of command line switches from a map"
-  [m & {:keys [underscore assign dash] :or {:dash "--"}}]
+  [m & {:keys [underscore assign dash] :or {dash "--"}}]
   (apply
    str (interpose
         " "


### PR DESCRIPTION
like 
usermod --comment "This is a whitespace comment"
