### PR TITLE
Updates to pallet.resource.filesystem/mount

### DIFF
--- a/src/pallet/resource/filesystem.clj
+++ b/src/pallet/resource/filesystem.clj
@@ -37,7 +37,8 @@
 (defn mount
   "Mount a device."
   [request device mount-point
-   & {:keys [device-type automount no-automount dump-frequency boot-check-pass]
+   & {:keys [fs-type device-type automount no-automount dump-frequency
+             boot-check-pass]
       :or {dump-frequency 0 boot-check-pass 0}
       :as options}]
   (->
@@ -45,6 +46,9 @@
    (directory/directory mount-point)
    (exec-script/exec-checked-script
     (format "Mount %s at %s" device mount-point)
-    (mount ~(mount-cmd-options
-             (dissoc options :device-type :dump-frequency :boot-check-pass))
-           ~device (quoted ~mount-point)))))
+    (if-not @(mountpoint -q ~mount-point)
+      (mount ~(if fs-type (str "-t " fs-type) "")
+             ~(mount-cmd-options
+               (dissoc options :device-type :dump-frequency :boot-check-pass
+                       :fs-type))
+             ~device (quoted ~mount-point))))))

--- a/test/pallet/resource/filesystem_test.clj
+++ b/test/pallet/resource/filesystem_test.clj
@@ -27,8 +27,23 @@
            (directory/directory "/mnt/a")
            (exec-script/exec-checked-script
             "Mount /dev/a at /mnt/a"
-            (mount "/dev/a" (quoted "/mnt/a")))))
+            (if-not @(mountpoint -q "/mnt/a")
+              (mount "/dev/a" (quoted "/mnt/a"))))))
          (first
           (test-utils/build-resources
            []
-           (filesystem/mount "/dev/a" "/mnt/a"))))))
+           (filesystem/mount "/dev/a" "/mnt/a")))))
+  (is (= (first
+          (test-utils/build-resources
+           []
+           (directory/directory "/mnt/a")
+           (exec-script/exec-checked-script
+            "Mount /dev/a at /mnt/a"
+            (if-not @(mountpoint -q "/mnt/a")
+              (mount -t "vboxsf" -o "gid=user,uid=user"
+                     "/dev/a" (quoted "/mnt/a"))))))
+         (first
+          (test-utils/build-resources
+           []
+           (filesystem/mount "/dev/a" "/mnt/a" :fs-type "vboxsf"
+                             :uid "user" :gid "user"))))))


### PR DESCRIPTION
This pull request updates pallet.resource.filesystem/mount to 
    \* Check if a filesystem is mounted before attempting to mount it again. 
    \* Accept the keyword arg :fs-type to specify the filesystem type when this is necessary. 

I also updated the unit test that these changes broke, and added a new one that hopefully tests the new functionality. Not sure I really understand these tests, it looks like they're just testing that the right bash is outputted by the function, so you may need to fix these up if I've got this wrong. 

All tests pass up to the point where the tests hang; we talked about this earlier on IRC, Hugo, wasn't sure how to resolve it to make the tests complete.
- David 
