### PR TITLE
Updated implementation of for->, with support for destructuring.

### DIFF
--- a/src/pallet/thread_expr.clj
+++ b/src/pallet/thread_expr.clj
@@ -8,18 +8,13 @@
         (for-> [x [1 2 3]]
           (+ x)))
    => 7"
-  [arg [value s & {:keys [let]}] & body]
-  (clojure.core/let
-   [argsym (gensym "arg")]
-   `(let [arg# ~arg s# ~s] ; maintain correct evaluation order
-      (reduce
-       (fn [~argsym ~value]
-         ~(if let
-            `(let ~let
-               (-> ~argsym ~@body))
-            `(-> ~argsym ~@body)))
-       arg#
-       s#))))
+  [arg seq-exprs body-expr]
+  `((apply comp (reverse
+                 (for ~seq-exprs
+                   (fn [arg#]
+                     (-> arg#
+                         ~body-expr)))))
+    ~arg))
 
 (defmacro when->
   "A `when` form that can appear in a request thread.

--- a/test/pallet/thread_expr_test.clj
+++ b/test/pallet/thread_expr_test.clj
@@ -4,7 +4,10 @@
    clojure.test))
 
 (deftest for->-test
-  (is (= 7 (-> 1 (for-> [x [1 2 3]] (+ x))))))
+  (is (= 7  (-> 1 (for-> [x [1 2 3]] (+ x)))))
+  (is (= 55  (-> 1 (for-> [x [1 2 3]
+                           y [2 3 4]
+                           :let [z (dec x)]] (+ x y z))))))
 
 (deftest when->test
   (is (= 2 (-> 1 (when-> true (+ 1)))))


### PR DESCRIPTION
Hugo, here's the for-> implementation I posted about, in irc.

Notes from commit --

The existing implementation of for-> supported the binding of a single
variable to a single sequence. The updated implementation here makes
use of clojure.core/for to build up a sequence of functions;
((apply comp functionseq) arg) is then used to thread the argument
among the sequences. Each item in the resulting sequence is dealt with
in order.
