### PR TITLE
More efficient implementation of for->

### DIFF
--- a/src/pallet/thread_expr.clj
+++ b/src/pallet/thread_expr.clj
@@ -11,9 +11,8 @@
   [arg seq-exprs & body]
   `(reduce #(%2 %1)
            ~arg
-           (conj (for ~seq-exprs
-                   (fn [arg#] (-> arg# ~@body)))
-                 identity)))
+           (for ~seq-exprs
+             (fn [arg#] (-> arg# ~@body)))))
 
 (defmacro when->
   "A `when` form that can appear in a request thread.


### PR DESCRIPTION
Ths version reduces reduces the list comprehension with an initial value of arg and the #(%2 %1) function, obviating the need to call reverse on the list comprehension!

(reduce #(%2 %1) arg function-sequence) ends up acting exactly like a call to comp with a reversed sequence.
