### PR TITLE
Add support for post 1.0 jclouds snapshot

### DIFF
--- a/src/pallet/compute/jclouds.clj
+++ b/src/pallet/compute/jclouds.clj
@@ -57,53 +57,36 @@
 ;;; Node utilities
 (defmacro impl-fns
   []
-  (let [ctors (.getDeclaredConstructors HardwareImpl)]
-    (if (= 10 (count (.getParameterTypes (first ctors))))
-      ;; jclouds up to beta-9c
-      `(do
-         (defn hardware-impl
-           [~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata ~'tags
-            ~'processors ~'ram ~'volumes ~'image-supported-fn]
-           (HardwareImpl.
-            ~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata
-            ~'processors ~'ram ~'volumes ~'image-supported-fn))
-         (defn node-metadata-impl
-           [~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata ~'tags
-            ~'group-name ~'hardware ~'image-id ~'os ~'state ~'login-port
-            ~'public-ips ~'private-ips ~'admin-password ~'credentials]
-           (NodeMetadataImpl.
-            ~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata
-            ~'group-name ~'hardware ~'image-id ~'os ~'state ~'login-port
-            ~'public-ips ~'private-ips ~'admin-password ~'credentials))
-         (defn image-impl
-           [~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata ~'tags
-            ~'os ~'description ~'version ~'admin-password ~'credentials]
-           (ImageImpl.
-            ~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata
-            ~'os ~'description ~'version ~'admin-password ~'credentials)))
-      ;; jclouds after beta-9c (added tags)
-      `(do
-         (defn hardware-impl
-           [~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata ~'tags
-            ~'processors ~'ram ~'volumes ~'image-supported-fn]
-           (HardwareImpl.
-            ~'provider-id ~'name ~'id ~'location ~'uri
-            ~'user-metadata ~'tags
-            ~'processors ~'ram ~'volumes ~'image-supported-fn))
-         (defn node-metadata-impl
-           [~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata ~'tags
-            ~'group-name ~'hardware ~'image-id ~'os ~'state ~'login-port
-            ~'public-ips ~'private-ips ~'admin-password ~'credentials]
-           (NodeMetadataImpl.
-            ~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata ~'tags
-            ~'group-name ~'hardware ~'image-id ~'os ~'state ~'login-port
-            ~'public-ips ~'private-ips ~'admin-password ~'credentials))
-         (defn image-impl
-           [~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata ~'tags
-            ~'os ~'description ~'version ~'admin-password ~'credentials]
-           (ImageImpl.
-            ~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata ~'tags
-            ~'os ~'description ~'version ~'admin-password ~'credentials))))))
+  (let [ctors (.getDeclaredConstructors NodeMetadataImpl)
+        ;; jclouds after 1.0 (added hostname)
+        has-hostname (= 18 (count (.getParameterTypes (first ctors))))]
+    `(do
+       (defn hardware-impl
+         [~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata ~'tags
+          ~'processors ~'ram ~'volumes ~'image-supported-fn]
+         (HardwareImpl.
+          ~'provider-id ~'name ~'id ~'location ~'uri
+          ~'user-metadata ~'tags
+          ~'processors ~'ram ~'volumes ~'image-supported-fn))
+       (defn node-metadata-impl
+         [~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata ~'tags
+          ~'group-name ~'hardware ~'image-id ~'os ~'state ~'login-port
+          ~'public-ips ~'private-ips ~'admin-password ~'credentials ~'hostname]
+         ~(if has-hostname
+            '(NodeMetadataImpl.
+              provider-id name id location uri user-metadata tags
+              group-name hardware image-id os state login-port
+              public-ips private-ips admin-password credentials hostname)
+            '(NodeMetadataImpl.
+              provider-id name id location uri user-metadata tags
+              group-name hardware image-id os state login-port
+              public-ips private-ips admin-password credentials)))
+       (defn image-impl
+         [~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata ~'tags
+          ~'os ~'description ~'version ~'admin-password ~'credentials]
+         (ImageImpl.
+          ~'provider-id ~'name ~'id ~'location ~'uri ~'user-metadata ~'tags
+          ~'os ~'description ~'version ~'admin-password ~'credentials)))))
 
 (impl-fns)
 
@@ -197,7 +180,8 @@
      (options :public-ips [])
      (options :private-ips [])
      (options :admin-password)
-     (options :credentials nil))))
+     (options :credentials nil)
+     (options :hostname ""))))
 
 (defn make-unmanaged-node
   "Make a node that is not created by pallet's node management.
@@ -229,7 +213,8 @@
      (conj (get options :public-ips []) host-or-ip)
      (options :private-ips [])
      (options :admin-password)
-     (options :credentials nil))))
+     (options :credentials nil)
+     (options :hostname ""))))
 
 
 (defn make-image


### PR DESCRIPTION
Hi Hugo,

I use jclouds-1.1.0-SNAPSHOT. This commit adds support in pallet.compute.jclouds for the next release:

```
NodeMetadataImpl gained an hostname argument in the constructor.
Also remove pre 1.0 support (Pallet depends on 1.0.0).
```
