### PR TITLE
fix for always using the default bridged network

### DIFF
--- a/src/pallet/compute/vmfest.clj
+++ b/src/pallet/compute/vmfest.clj
@@ -404,7 +404,7 @@
                  parallel-create-nodes)
          target-machines-to-create server (:node-path locations)
          group-spec @images image-id
-         {:micro (machine-model template)}
+         {:micro (machine-model (@images image-id))}
          group-name init-script user))))
 
   (reboot


### PR DESCRIPTION
the image template was being used to set the paramters for the deployed instance instead of the image delected by that template. 

This had the effect of causing the bridged-network parameter (amongst others) to be dropped from
the image specification making it impossable to use anything other than the default bridged network
device. This change allows pallet to use vmfest on ubuntu.
