### PR TITLE
If a node has no public IP, use the private IP

### DIFF
--- a/src/pallet/node.clj
+++ b/src/pallet/node.clj
@@ -27,6 +27,7 @@
 
 (defn node-address
   [node]
-  (if (string? node)
-    node
-    (primary-ip node)))
+  (cond
+    (string? node) node
+    (primary-ip node) (primary-ip node)
+    :else (private-ip node)))

--- a/test/pallet/node_test.clj
+++ b/test/pallet/node_test.clj
@@ -1,0 +1,11 @@
+(ns pallet.node-test
+  (:use
+    clojure.test
+    [pallet.node :only [node-address]]
+    [pallet.compute.node-list :only [make-node]]))
+
+(deftest node-address-test
+  (let [ip "1.2.3.4"]
+    (is (= ip (node-address (make-node nil nil ip nil))))
+    (is (= ip (node-address
+                (make-node nil nil nil nil :id "id" :private-ip ip))))))


### PR DESCRIPTION
When setting up a node that has no public IP (in a VPC), the
`:server` attribute of the session's `:ssh` map is empty, since
`node-address` returns only the public IP. This patch returns the
private IP if no public IP could be found.

This should make sense in any branch, but I use `support/0.7.x`
