### PR TITLE
Fix stack overflow error in supported-providers

### DIFF
--- a/src/pallet/compute/implementation.clj
+++ b/src/pallet/compute/implementation.clj
@@ -14,7 +14,8 @@
 
 (def compute-prefix "pallet.compute")
 (def exclude-compute-ns
-  #{'pallet.compute.jvm
+  #{'pallet.compute
+    'pallet.compute.jvm
     'pallet.compute.implementation})
 (def exclude-regex #".*test.*")
 (def provider-list (atom nil))


### PR DESCRIPTION
Repl session on develop HEAD:

```
user=> (require 'pallet.compute)
nil
user=> (pallet.compute/supported-providers)
StackOverflowError 
```

This was caused by a mutual recursive invocation of supported-providers in:

(p.c/supported-providers)->>(p.c.i/supported-providers)->(p.c/supported-providers)...
