### PR TITLE
Resolve inconsistent Mac OS X naming

### DIFF
--- a/src/pallet/compute.clj
+++ b/src/pallet/compute.clj
@@ -112,7 +112,7 @@
       (derive :arch :arch-base)
       (derive :gentoo :gentoo-base)
       (derive :darwin :bsd-base)
-      (derive :osx :bsd-base)))
+      (derive :os-x :bsd-base)))
 
 (defmacro defmulti-os
   "Defines a defmulti used to abstract over the target operating system. The


### PR DESCRIPTION
`pallet.compute/os-hierarchy` refers to Mac OS X with `:osx`. The rest of the code in Pallet uses `:os-x`. I don't have a strong opinion on which to use, but altering `os-hierarchy` seems to be the simplest fix.
