### PR TITLE
remove tempfiles after running scripts remotely

### DIFF
--- a/src/pallet/ssh/execute.clj
+++ b/src/pallet/ssh/execute.clj
@@ -83,6 +83,10 @@
             ;; the script.
             session (assoc-in
                      session [:plan-state :node-values node-value-path] result)]
+        (transport/exec
+          connection
+          {:execv [(stevedore/script (rm -f ~tmpfile))]}
+          {})
         [(update-in result [:out] clean-f) session]))))
 
 (defn- ssh-upload


### PR DESCRIPTION
prevents tempfiles from laying around
