### PR TITLE
If a node has no image-user, use the environment one.

### DIFF
--- a/src/pallet/compute/node_list.clj
+++ b/src/pallet/compute/node_list.clj
@@ -70,12 +70,15 @@
    proxy
    image-user))
 
-(deftype NodeTagUnsupported
-    []
+(deftype NodeTagStatic
+    [static-tags]
   pallet.compute.NodeTagReader
-  (node-tag [_ node tag-name] nil)
-  (node-tag [_ node tag-name default-value] default-value)
-  (node-tags [_ node] nil)
+  (node-tag [_ node tag-name] 
+    (get static-tags tag-name))
+  (node-tag [_ node tag-name default-value] 
+    (or (get static-tags tag-name) default-value))
+  (node-tags [_ node] 
+    static-tags)
   pallet.compute.NodeTagWriter
   (tag-node! [_ node tag-name value]
     (throw
@@ -172,7 +175,7 @@ support."
 
 (defmethod implementation/service :node-list
   [_ {:keys [node-list environment tag-provider]
-      :or {tag-provider (NodeTagUnsupported.)}}]
+      :or {tag-provider (NodeTagStatic. {:bootstrapped true})}}]
   (let [nodes (atom (vec
                      (map
                       #(if (vector? %)

--- a/src/pallet/core/api.clj
+++ b/src/pallet/core/api.clj
@@ -145,9 +145,7 @@
   (fn [node]
     (let [user (into {} (filter val (image-user (:node node))))]
       (debugf "Image-user is %s" user)
-      {:user (if (seq user)
-               user
-               (:user environment))
+      {:user user
        :executor (get-in environment [:algorithms :executor] default-executor)
        :executor-status-fn (get-in environment [:algorithms :execute-status-fn]
                                    #'stop-execution-on-error)})))
@@ -324,8 +322,7 @@
   [state-name]
   (fn [node]
     (get
-     (when (taggable? (:node node))
-       (read-or-empty-map (tag (:node node) state-tag-name)))
+     (read-or-empty-map (tag (:node node) state-tag-name))
      (keyword (name state-name)))))
 
 ;;; # Exception reporting

--- a/test/pallet/compute/node_list_test.clj
+++ b/test/pallet/compute/node_list_test.clj
@@ -46,9 +46,10 @@
     (is (= node-list (node/compute-service node)))
     (is (nil? (node/tag node "some-tag")))
     (is (= ::x (node/tag node "some-tag" ::x)))
-    (is (empty? (node/tags node)))
+    (is (= {:bootstrapped true} (node/tags node)))
     (is (thrown? Exception (node/tag! node "tag" "value")))
-    (is (not (node/taggable? node)))))
+    (is (not (node/taggable? node)))
+    (is (= true (node/tag node :bootstrapped)))))
 
 (deftest close-test
   (is (nil? (compute/close


### PR DESCRIPTION
This is almost always the case using the node-list provider where nodes are initialized without image-user, and the image-user function from the NodeImage protocol always return nil.
