### PR TITLE
Fixed DEBUG log exception for :admin-user without keypaths.

### DIFF
--- a/src/pallet/main_invoker.clj
+++ b/src/pallet/main_invoker.clj
@@ -25,10 +25,10 @@
         ^String public-key-path (:public-key-path admin-user)]
     (logging/debugf
      "private-key-path %s %s"
-     private-key-path (.canRead (java.io.File. (or private-key-path ""))))
+     private-key-path (if private-key-path (.canRead (java.io.File. private-key-path)) ""))
     (logging/debugf
      "public-key-path %s %s"
-     public-key-path (.canRead (java.io.File. (or public-key-path ""))))
+     public-key-path (if public-key-path (.canRead (java.io.File. public-key-path)) ""))
     (doseq [^java.io.File f (classpath-files)]
       (logging/debugf "classpath: %s" (.getPath f)))
     (doseq [[k v] (System/getProperties)]


### PR DESCRIPTION
If the admin-user defined in the environment is defined with :username and :password and without private-key-path/public-key-path pair, when DEBUG log was turned on for pallet.main-invoker it failed with a NullPointerException.

Now if values are nil empty string is logged instead.
