### PR TITLE
Changed short option for phases cmd line argument

### DIFF
--- a/src/pallet/task/up.clj
+++ b/src/pallet/task/up.clj
@@ -23,7 +23,7 @@
     :default "default"]
    ["-g" "--groups" "A comma separated list of groups"]
    ["-r" "--roles" "A comma separated list of group roles"]
-   ["-p" "--phases" "A comma separated list of phases"]
+   ["-a" "--phases" "A comma separated list of phases"]
    ["-d" "--dry-run" "Don't run anything, just show matching groups"
     :flag true]
    ["-f" "--format" "Output nodes in a table [table,edn]"


### PR DESCRIPTION
Short option for phases changed from "-p" to "-a" as "-p" is reserved for provider selection

Fixes https://github.com/pallet/pallet-lein/issues/9 for lein plugin.
