### PR TITLE
Add :apt to debconf script implementations

### DIFF
--- a/src/pallet/script/lib.clj
+++ b/src/pallet/script/lib.clj
@@ -709,13 +709,13 @@
 
 (script/defscript debconf-set-selections [& selections])
 (script/defimpl debconf-set-selections :default [& selections] "")
-(script/defimpl debconf-set-selections [#{:aptitude}] [& selections]
+(script/defimpl debconf-set-selections [#{:aptitude :apt}] [& selections]
   ("{ debconf-set-selections"
    ~(str "<<EOF\n" (string/join \newline selections) "\nEOF\n}")))
 
 (script/defscript package-manager-non-interactive [])
 (script/defimpl package-manager-non-interactive :default [] "")
-(script/defimpl package-manager-non-interactive [#{:aptitude}] []
+(script/defimpl package-manager-non-interactive [#{:aptitude :apt}] []
   (~debconf-set-selections
    "debconf debconf/frontend select noninteractive"
    "debconf debconf/frontend seen false"))

--- a/test/pallet/script/lib_test.clj
+++ b/test/pallet/script/lib_test.clj
@@ -229,6 +229,27 @@
        (script/with-script-context [:yum]
          (script (~list-installed-packages))))))
 
+(deftest debconf-test
+  (script/with-script-context [:apt]
+    (is (script-no-comment=
+          "{ debconf-set-selections <<EOF\ndebconf string\nEOF\n}"
+          (debconf-set-selections "debconf string")))
+    (is (script-no-comment=
+          (str "{ debconf-set-selections <<EOF\n"
+               "debconf debconf/frontend select noninteractive\n"
+               "debconf debconf/frontend seen false\nEOF\n"
+               "}")
+          (package-manager-non-interactive))))
+  (script/with-script-context [:aptitude]
+    (is (script-no-comment=
+          "{ debconf-set-selections <<EOF\ndebconf string\nEOF\n}"
+          (debconf-set-selections "debconf string")))
+    (is (script-no-comment=
+          (str "{ debconf-set-selections <<EOF\n"
+               "debconf debconf/frontend select noninteractive\n"
+               "debconf debconf/frontend seen false\nEOF\n"
+               "}")
+          (package-manager-non-interactive)))))
 
 
 


### PR DESCRIPTION
As discussed briefly in IRC, with :packager :apt, debconf scripts wouldn't run.
