### PR TITLE
fix service-script failing on check-spec

### DIFF
--- a/src/pallet/actions.clj
+++ b/src/pallet/actions.clj
@@ -852,7 +852,7 @@ Deprecated in favour of pallet.crate.service/service."
      pallet.actions/remote-file
      (service-script-path service-impl service-name)
      :owner "root" :group "root" :mode "0755"
-     (merge {:action action} options))))
+     (merge {:action action} (dissoc options :service-impl)))))
 
 ;;; # Retry
 ;;; TODO: convert to use a nested scope in the action-plan


### PR DESCRIPTION
Hi,

On [this project](https://github.com/cldwalker/datomic-box), I'm trying to use datomic-crate with beta.10 and it fails while trying to use [service-script](https://github.com/rstradling/datomic-crate/blob/master/src/pallet/crate/datomic.clj#L79) with this error:

```
ExceptionInfo Invalid remote-file-arguments: Path [:service-impl] was not specified in the schema.  clojure.core/ex-info (core.clj:4327)
```

I traced this to `service-script` and it seems that a `check-spec` was recently added. This pull removes an extraneous key that fails the check.

Thanks for the great work you all are doing!
