### PR TITLE
Add :extract-files option to 'remote-directory

### DIFF
--- a/src/pallet/actions.clj
+++ b/src/pallet/actions.clj
@@ -533,6 +533,9 @@ Options:
 `:strip-components`
 : number of path compnents to remove when unpacking
 
+`:extract-files`
+: extract only the specified files or directories from the archive
+
 `:md5`
 : md5 of file to unpack
 
@@ -567,7 +570,15 @@ option and :unpack :unzip.
 
     (remote-directory session path
        :url \"http://a.com/path/file.\"
-       :unpack :unzip)"
+       :unpack :unzip)
+
+To install the content of an url pointing at a jar/tar/zip file, extracting
+only specified files or directories, use the :extract-files option.
+
+    (remote-directory session path
+       :url \"http://a.com/path/file.jar\"
+       :unpack :jar
+       :extract-files [\"dir/file\" \"file2\"])"
   {:pallet/plan-fn true}
   [path & {:keys [action url local-file remote-file
                   unpack tar-options unzip-options jar-options

--- a/test/pallet/actions/direct/remote_directory_test.clj
+++ b/test/pallet/actions/direct/remote_directory_test.clj
@@ -100,6 +100,43 @@
                  :unpack :tar
                  :owner "fred"
                  :recursive false)))))
+  (is (script-no-comment=
+       (with-session {:environment {:user *admin-user*}}
+         (binding [pallet.action-plan/*defining-context* nil]
+           (stevedore/do-script
+            (stevedore/checked-commands
+             "remote-directory"
+             (-> (directory* {} "/path" :owner "fred" :recursive false)
+                 first second)
+             (-> (remote-file*
+                  {} (fragment (lib/file (lib/tmp-dir) "file.tgz"))
+                  {:url "http://site.com/a/file.tgz" :md5 nil})
+                 first second)
+             (stevedore/script
+              (when (or (not (file-exists?
+                              (lib/file (lib/tmp-dir) "file.tgz.md5")))
+                        (or (not (file-exists? "/path/.pallet.directory.md5"))
+                            (not ("diff" (lib/file (lib/tmp-dir) "file.tgz.md5")
+                                  "/path/.pallet.directory.md5"))))
+                ~(stevedore/checked-script
+                  (str "Untar " (fragment (lib/file (lib/tmp-dir) "file.tgz")))
+                  (var rdf @("readlink" -f (lib/file (lib/tmp-dir) "file.tgz")))
+                  ("cd" "/path")
+                  ("tar" xz "--strip-components=0" -f "${rdf}" "dir/file file2")
+                  ("cd" -))
+                (when (file-exists? (lib/file (lib/tmp-dir) "file.tgz.md5"))
+                  ("cp" (lib/file (lib/tmp-dir) "file.tgz.md5")
+                   "/path/.pallet.directory.md5"))))))))
+       (first (build-actions/build-actions
+                  {}
+                (remote-directory
+                 "/path"
+                 :url "http://site.com/a/file.tgz"
+                 :unpack :tar
+                 :strip-components 0
+                 :extract-files ["dir/file" "file2"]
+                 :owner "fred"
+                 :recursive false)))))
   (with-temporary [tmp (tmpfile)]
     (is (first (build-actions/build-actions
                    {}


### PR DESCRIPTION
Allows the specification of which files or directories to extract from a
jar, zip or tar archive.
