### PR TITLE
:all-node-set is missing in 'lift-option-schema'

### DIFF
--- a/src/pallet/contracts.clj
+++ b/src/pallet/contracts.clj
@@ -150,7 +150,8 @@
    (optional-path [:timeout-val]) any-value
    (optional-path [:debug :script-comments]) any-value
    (optional-path [:debug :script-trace]) any-value
-   (optional-path [:os-detect]) any-value])
+   (optional-path [:os-detect]) any-value
+   (optional-path [:all-node-set]) set?])
 
 (def-map-schema converge-options-schema
   lift-options-schema


### PR DESCRIPTION
A one-liner to add :all-node-set in 'lift-option-schema'. 

David
