### PR TITLE
fix some typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ characters and that describes the changeset concisely, followed by a blank line,
 followed by a more detailed explanation.
 
 See [progit](http://progit.org/book/ch5-2.html#commit_guidelines) for a more
-complete explaination of commit messages.
+complete explanation of commit messages.
 
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ command line.
 - reuse configuration in development, testing and production.
 - store all your configuration in a source code management system (eg. git),
   including role assignments.
-- configuration is re-used by compostion; just create new functions that call
+- configuration is re-used by composition; just create new functions that call
   existing crates with new arguments. No copy and modify required.
 - enable use of configuration crates (recipes) from versioned jar files.
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -134,7 +134,7 @@ Unstable development branch
   If an exception is thrown when reading a pallet config file, ensures the 
   path of the config file appears in the exception message.
 
-- Rename aciton-options key to ::action-options
+- Rename action-options key to ::action-options
 
 - Move action-options into :plan-state
   This will allow action options to be passed into lift and converge.
@@ -215,7 +215,7 @@ Unstable development branch
 
 - Add blobstore function to pallet.crate
 
-- Add local vairables for clojure-mode indents
+- Add local variables for clojure-mode indents
 
 ## Fixes
 
@@ -237,7 +237,7 @@ Unstable development branch
 
 - Ensure correct permissions under /var/lib/pallet
   The ownership and permissions under /var/lib/pallet should mirror the
-  ownership and permissiond of the reflected filesystem, otherwise difficult
+  ownership and permission of the reflected filesystem, otherwise difficult
   to understand permission problems occur.
 
 - Correct several namespace requires
@@ -493,7 +493,7 @@ Unstable development branch
 
   Closes #223.
 
-- Fix mergeing of environment phases
+- Fix merging of environment phases
 
 - Fix lift task for updated project-groups arity
 
@@ -621,7 +621,7 @@ Unstable development branch
 
 - Ensure asserts within plan functions are reported
 
-- Create temp directorys under TEMPDIR on osx
+- Create temp directories under TEMPDIR on osx
 
 - Make md5 checking on os x more robust
 
@@ -805,7 +805,7 @@ Unstable development branch
 - Remove dependency on CompilerException
 
 - Add dependency message on project file failure
-  When a task fails to load the projec pallet.clj file, output a message
+  When a task fails to load the project pallet.clj file, output a message
   that explains that a dependency needs to be added.
 
 - Change group ID to com.palletops, pom.xml, and lein project.clj
@@ -1083,7 +1083,7 @@ Unstable development branch
 
 - Make target-flag? callable as a plan function
 
-- Add target crate funtion
+- Add target crate function
   Returns the denormalised map for the target node.
 
 - Add assertf plan function
@@ -1178,11 +1178,11 @@ Unstable development branch
 
 - Fix use of package-source in crate-install
 
-- Add a confirmation to add-apt-repository in pacakage-source
+- Add a confirmation to add-apt-repository in package-source
 
 - Fix live-test
   Neither the environment nor existing nodes were being used when
-  convereging nodes for a test.
+  converging nodes for a test.
 
 - Ensure the state after a final plan function is verified
   Due to optimisations in clojure.algo.monads, the final state in a chain-s
@@ -1229,7 +1229,7 @@ Unstable development branch
 - Quieten p.actions.direct.settings-test
 
 - Factor out lift* and converge* in pallet.api
-  The lift* and converge* fuctions return the fsms used by left and
+  The lift* and converge* functions return the fsms used by left and
   converge respectively, without calling operate on them.
 
 - Improve etc-hosts docstring and tests
@@ -1360,7 +1360,7 @@ Unstable development branch
 - Fix rsync-directory action to not install rsync
   We would like to ensure rsync is installed, but this requires root
   permissions, and doesn't work when the action is run without root
-  permision.
+  permission.
 
 - Fix pipeline-when to correctly handle keywords used as functions
 
@@ -1380,7 +1380,7 @@ Unstable development branch
 - Add node tagging SPI
   Closes #139
 
-- Fix converge for denormailsed nodes
+- Fix converge for denormalised nodes
 
 - Fix pipeline-when for new stevedore test expression generation
 

--- a/src/pallet/action_plan.clj
+++ b/src/pallet/action_plan.clj
@@ -536,7 +536,7 @@
             (nil? (second action-plan)))))
 
 (defn map-action-f
-  "Map exec-action over actions in the action-plan, applying sesssion."
+  "Map exec-action over actions in the action-plan, applying session."
   [exec-action action-plan session]
   ((domonad action-exec-m [v (m-map exec-action action-plan)] v)
    session))

--- a/src/pallet/actions.clj
+++ b/src/pallet/actions.clj
@@ -398,7 +398,7 @@ Options for version control are:
 : do not version the file
 
 `max-versions`
-: specfy the number of versions to keep (default 5)
+: specify the number of versions to keep (default 5)
 
 `flag-on-changed`
 : flag to set if file is changed
@@ -531,7 +531,7 @@ Options:
   components
 
 `:strip-components`
-: number of path compnents to remove when unpacking
+: number of path components to remove when unpacking
 
 `:extract-files`
 : extract only the specified files or directories from the archive
@@ -559,7 +559,7 @@ option.
        :url \"http://a.com/path/file.tgz\")
 
 If there is an md5 url with the tar file's md5, you can specify that as well,
-to prevent unecessary downloads and verify the content.
+to prevent unnecessary downloads and verify the content.
 
     (remote-directory session path
        :url \"http://a.com/path/file.tgz\"
@@ -663,7 +663,7 @@ only specified files or directories, use the :extract-files option.
    - :list-installed  - output a list of the installed packages
    - :add-scope       - enable a scope (eg. multiverse, non-free)
 
-   To refresh the list of packages known to the pakage manager:
+   To refresh the list of packages known to the package manager:
        (package-manager session :update)
 
    To enable multiverse on ubuntu:
@@ -829,7 +829,7 @@ Specify `:line` as a string, or `:package`, `:question`, `:type` and
   "Control services.
 
    - :action  accepts either startstop, restart, enable or disable keywords.
-   - :if-flag  makes start, stop, and restart confitional on the specified flag
+   - :if-flag  makes start, stop, and restart conditional on the specified flag
                as set, for example, by remote-file :flag-on-changed
    - :sequence-start  a sequence of [sequence-number level level ...], where
                       sequence number determines the order in which services

--- a/src/pallet/api.clj
+++ b/src/pallet/api.clj
@@ -72,7 +72,7 @@
 
    :location  a map describing a predicate for matching location:
               location-id
-   :hardware  a map describing a predicate for matching harware:
+   :hardware  a map describing a predicate for matching hardware:
               min-cores min-ram smallest fastest biggest architecture
               hardware-id
    :network   a map for network connectivity options:

--- a/src/pallet/core/data_api.clj
+++ b/src/pallet/core/data_api.clj
@@ -15,7 +15,7 @@
 
 (defn- mock-exec-plan
   "Creates mock provider with a mock node, and a mock group, and then lifts
- the plan funcion `pfn` on such group. "
+ the plan function `pfn` on such group. "
   [executor pfn node & {:keys [settings-phase ]}]
   (let [compute (node-list-service [node])
         group-name (second node)

--- a/src/pallet/core/operations.clj
+++ b/src/pallet/core/operations.clj
@@ -184,7 +184,7 @@
   "Partition targets using the, possibly nil, default partitioning function f.
 
 There are three sources of partitioning applied.  The default passed to the
-function, a paritioning based on the partitioning and post-phase functions in
+function, a partioning based on the partitioning and post-phase functions in
 the target's metadata, and the target's partitioning function from the metadata.
 
 The partitioning by metadata is applied so that post-phase functions are applied

--- a/src/pallet/core/primitives.clj
+++ b/src/pallet/core/primitives.clj
@@ -125,7 +125,7 @@
      service-state plan-state environment execution-settings-f action-plans)))
 
 (defn execute-and-flag
-  "Return a phase execution function, that will exacute a phase on nodes that
+  "Return a phase execution function, that will execute a phase on nodes that
   don't have the specified state flag set. On successful completion the nodes
   have the state flag set."
   ([state-flag execute-f]
@@ -150,7 +150,7 @@
      (execute-and-flag state-flag build-and-execute-phase)))
 
 (defn execute-on-filtered
-  "Return a phase execution function, that will exacute a phase on nodes that
+  "Return a phase execution function, that will execute a phase on nodes that
   have the specified state flag set."
   [filter-f execute-f]
   (logging/tracef "execute-on-filtered")
@@ -166,7 +166,7 @@
       [results plan-state])))
 
 (defn execute-on-flagged
-  "Return a phase execution function, that will exacute a phase on nodes that
+  "Return a phase execution function, that will execute a phase on nodes that
   have the specified state flag set."
   ([state-flag execute-f]
      (logging/tracef "execute-on-flagged state-flag %s" state-flag)
@@ -177,7 +177,7 @@
      (execute-on-flagged state-flag build-and-execute-phase)))
 
 (defn execute-on-unflagged
-  "Return a phase execution function, that will exacute a phase on nodes that
+  "Return a phase execution function, that will execute a phase on nodes that
   have the specified state flag set."
   ([state-flag execute-f]
      (logging/tracef "execute-on-flagged state-flag %s" state-flag)

--- a/src/pallet/crate/limits_conf.clj
+++ b/src/pallet/crate/limits_conf.clj
@@ -44,7 +44,7 @@
 
   A host entry can be either a map with :domain, :type, :item and :value keys,
   or a vector specifying strings for the fields (in domain, type, item, value
-  order).  The type and item vlaues may optionally be keywords."
+  order).  The type and item values may optionally be keywords."
   [entry & {:keys [instance-id] :as options}]
   {:pre [(or (vector? entry) (map? entry))]}
   (update-settings :limits-conf options

--- a/src/pallet/crate/package/jpackage.clj
+++ b/src/pallet/crate/package/jpackage.clj
@@ -56,7 +56,7 @@
      redhat-el
 
    Installs the jpackage-utils package from the base repos at a
-   pritority of 25."
+   priority of 25."
   [& {:keys [version component releasever enabled]
       :or {component "redhat-el"
            releasever "$releasever"

--- a/src/pallet/crate/ssh_key.clj
+++ b/src/pallet/crate/ssh_key.clj
@@ -83,7 +83,7 @@
      :filename path -- output file name (within ~user/.ssh directory)
      :type key-type -- key type selection
      :no-dir true   -- do note ensure directory exists
-     :passphrase    -- new passphrase for encrypring the private key
+     :passphrase    -- new passphrase for encrypting the private key
      :comment       -- comment for new key"
   [user & {:keys [type filename passphrase no-dir comment]
            :or {type "rsa" passphrase ""}
@@ -126,7 +126,7 @@ Passing a :filename value allows direct specification of the filename.
 (defplan config
   "Update an ssh config file. Sets the configuration for `host` to be that given
 by the key-value-map.  Optionally allows specification of the `user` whose ssh
-config ffile is to be modified, and the full `config-file` path."
+config file is to be modified, and the full `config-file` path."
   [host key-value-map & {:keys [user config-file]
                          :or {user (:username (admin-user))}}]
   (let [content (str "Host " host \newline

--- a/src/pallet/execute.clj
+++ b/src/pallet/execute.clj
@@ -93,7 +93,7 @@
     session))
 
 (defn set-target-flag-values
-  "Set flag valuess for target."
+  "Set flag values for target."
   [session flag-values]
   (if (seq flag-values)
     (update-in

--- a/src/pallet/feature.clj
+++ b/src/pallet/feature.clj
@@ -34,7 +34,7 @@
     false-expr))
 
 (defn multilang-script
-  "Feature for multi-langauge script execution."
+  "Feature for multi-language script execution."
   [] true)
 
 (defn run-nodes-without-bootstrap

--- a/src/pallet/session/verify.clj
+++ b/src/pallet/session/verify.clj
@@ -10,11 +10,11 @@
 
 (defn check-session
   "Function that can check a session map to ensure it is a valid part of
-   phase definiton. It returns the session map.
+   phase definition. It returns the session map.
 
    If this fails, then it is likely that you have an incorrect crate function
    which is failing to return its session map properly, or you have a non crate
-   function in the phase defintion."
+   function in the phase definition."
   ([session]
      ;; we do not use a precondition in order to improve the error message
      (when-not (and session (map? session) (session-verification-key session))

--- a/src/pallet/utils.clj
+++ b/src/pallet/utils.clj
@@ -96,7 +96,7 @@
        (find-var-with-require 'my.ns/a-symbol)
 
    If the namespace exists, but can not be loaded, and exception is thrown.  If
-   the namsepace is loaded, but the symbol is not found, then nil is returned."
+   the namespace is loaded, but the symbol is not found, then nil is returned."
   ([sym]
      (find-var-with-require (symbol (namespace sym)) (symbol (name sym))))
   ([ns sym]

--- a/src/pallet/version_dispatch.clj
+++ b/src/pallet/version_dispatch.clj
@@ -50,7 +50,7 @@ data may provide a version."
            :version version}))))))
 
 (defmacro defmulti-version
-  "Defines a multi-version funtion used to abstract over an operating system
+  "Defines a multi-version function used to abstract over an operating system
 hierarchy, where dispatch includes an optional `os-version`. The `version`
 refers to a software package version of some sort, on the specified `os` and
 `os-version`."
@@ -83,7 +83,7 @@ refers to a software package version of some sort, on the specified `os` and
               ~@body))))
 
 (defmacro defmulti-version-plan
-  "Defines a multi-version funtion used to abstract over an operating system
+  "Defines a multi-version function used to abstract over an operating system
 hierarchy, where dispatch includes an optional `os-version`. The `version`
 refers to a software package version of some sort, on the specified `os` and
 `os-version`."


### PR DESCRIPTION
Caught a number of typos with [lein-spell](https://github.com/cldwalker/lein-spell).

If you'd like to catch future typos without false positives, this is your local whitelist that goes in.lein-spell:

```
assertf
authorise
basicdemo
chiba
cljstart
cmnd
customisation
debugf
denormalised
enlive
favourite
fixup
fsmop
invoker
jsch
juergenhoetzel
keypaths
mygroup
mynodes
normalisation
optimisations
organisation
palletops
preseeds
quantal
rsyncing
sanitise
serialise
ulimits
unflagged
useable
```
