### PR TITLE
Fix cluster-spec to not break when cluster-name is a keyword

### DIFF
--- a/src/pallet/api.clj
+++ b/src/pallet/api.clj
@@ -279,7 +279,7 @@ specified in the `:extends` argument."
                       (extend-specs [(select-keys group-spec [:phases])])))
                    (expand-group-spec-with-counts group-specs 1))))
      (dissoc :extends :node-spec)
-     (assoc :cluster-cluster-name (keyword cluster-name))
+     (assoc :cluster-name (keyword cluster-name))
      (vary-meta assoc :type ::cluster-spec))))
 
 ;;; ## Compute Service


### PR DESCRIPTION
Two tiny fixes:
- first one ensures that cluster-spec allows cluster-name to be a keyword;
- second one fixes a typo in server-spec.

-David
