### PR TITLE
allow vmfest shared folders in hardware spec schema

### DIFF
--- a/src/pallet/contracts.clj
+++ b/src/pallet/contracts.clj
@@ -51,7 +51,8 @@
   [(optional-path [:hardware-id]) string?
    (optional-path [:min-ram]) number?
    (optional-path [:min-cores]) number?
-   (optional-path [:min-disk]) number?])
+   (optional-path [:min-disk]) number?
+   (optional-path [:hardware-model]) map?])
 
 (def-map-schema inbound-port-spec-schema
   [[:start-port] number?


### PR DESCRIPTION
The contract for hardware spec's does not allow passing the hardware-model used by vmfest to define shared folders. With this change shared folders can be defined in a pallet group spec like so:

``` clojure

(group-spec "media-vms"                                                                                                                                                   
              :count 1                                                                                                                                                    
              :node-spec {:image {:image-id :ubuntu-12.04}                                                                                                                
                          :hardware {:hardware-model {:shared-folders [["music" "/raid/music" nil true]]}}}                                                               
              :phases { :configure (plan-fn                                                                                                                               
                                   (exec-checked-script                                                                                                                   
                                    "mount shared-folder (only once, not on reboot)"                                                                                      
                                    "mkdir -p /music"                                                                                                                     
                                    "mount -t vboxsf music /music"))})
```
