### PR TITLE
assoc call requires key-val pairs

### DIFF
--- a/src/pallet/action_plan.clj
+++ b/src/pallet/action_plan.clj
@@ -334,7 +334,7 @@
   "Convert a scope to a single script function"
   [action-map]
   (if (= :nested-scope (:action-type action-map))
-    (assoc action-map :action-type :script/bash :target)
+    (assoc action-map :action-type :script/bash :location :target)
     action-map))
 
 (defn- script-type-scopes-in-scope


### PR DESCRIPTION
I assume that `:target` is intended to be a value here.  Also, clojure 1.4 throws an exception when it is passed odd-number of key/vals to assoc: https://github.com/clojure/clojure/blob/master/src/clj/clojure/core.clj#L193 .
