### PR TITLE
pallet.core.api/environment-image-execution-settings should use ssh username provided by caller

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.yummly/pallet "0.8.0-RC.1.1"
+(defproject com.palletops/pallet "0.8.0-SNAPSHOT"
   :description
   "DevOps for the JVM.
 


### PR DESCRIPTION
I'm using pallet with ec2.

I have a node-spec which specifies :image/:override-login-user. I run converge and specify :user there as well.

When it goes to operate on the node and tries to ssh there, the username is empty because it looks like the information I'm passing is not being used, and instead it expects jclouds to discover the username it should use for ssh.

The fix below works for me but I'm not sure it's the right/best thing to do. 
