### PR TITLE
Fix #277. Check for /selinux/enforce before issuing 'chcon'.

### DIFF
--- a/src/pallet/script/lib.clj
+++ b/src/pallet/script/lib.clj
@@ -952,7 +952,8 @@
   [path type]
   (if (&& (~has-command? chcon)
           (&& (directory? "/etc/selinux")
-              ("stat" --format "%C" ~path "2>&-")))
+              (&& (file-exists? "/selinux/enforce")
+                  ("stat" --format "%C" ~path "2>&-"))))
     ("chcon" -Rv ~(str "--type=" type) ~path)))
 
 (script/defscript selinux-bool


### PR DESCRIPTION
This fix allows automate-admin-user to work with Centos 5.7 (and possibly other distros)
