### PR TITLE
Add create-admin function

### DIFF
--- a/pallet.clj
+++ b/pallet.clj
@@ -10,7 +10,8 @@
            operations-test rolling-lift-test
            partitioning-test exec-meta-test]]
  '[pallet.crate.initd-test :refer [initd-test-spec]]
- '[pallet.crate.nohup-test :refer [nohup-test-spec]])
+ '[pallet.crate.nohup-test :refer [nohup-test-spec]]
+ '[pallet.crate.automated-admin-user-test :refer [create-admin-test-spec]])
 
 (defproject pallet
   :provider {:vmfest
@@ -31,4 +32,7 @@
            (group-spec "nohup-test"
              :extends [with-automated-admin-user
                        nohup-test-spec]
-             :roles #{:live-test :default :nohup})])
+             :roles #{:live-test :default :nohup})
+           (group-spec "create-admin-test"
+             :extends [create-admin-test-spec]
+             :roles #{:live-test :default :create-admin})])

--- a/src/pallet/crate/automated_admin_user.clj
+++ b/src/pallet/crate/automated_admin_user.clj
@@ -1,10 +1,13 @@
 (ns pallet.crate.automated-admin-user
   (:require
-   [pallet.actions :refer [package-manager user]]
-   [pallet.api :refer [plan-fn server-spec]]
+   [pallet.actions :refer [directory package-manager plan-when-not user]]
+   [pallet.api :refer [plan-fn] :as api]
    [pallet.crate :refer [admin-user defplan]]
    [pallet.crate.ssh-key :as ssh-key]
-   [pallet.crate.sudoers :as sudoers]))
+   [pallet.crate.sudoers :as sudoers]
+   [pallet.script.lib :refer [user-home]]
+   [pallet.stevedore :refer [fragment]]
+   [pallet.utils :refer [apply-map]]))
 
 (defplan authorize-user-key
   "Authorise a single key, specified as a path or as a byte array."
@@ -12,6 +15,87 @@
   (if (string? path-or-bytes)
     (ssh-key/authorize-key username (slurp path-or-bytes))
     (ssh-key/authorize-key username (String. ^bytes path-or-bytes))))
+
+(defn create-user-and-home
+  [username create-user create-home user-options]
+  (cond
+   (= ::unspecified create-user)
+   (do
+     ;; if create-user not forced, only run if no existing user,
+     ;; so we can run in the presence of pam_ldap users.
+     (plan-when-not (fragment ("getent" passwd ~username))
+       (apply-map user username (merge
+                                 {:create-home true :shell :bash}
+                                 user-options)))
+     ;; If the user exists and the home directory does not then
+     ;; create it. This is to allow for pam_mkhomedir, and is a hack,
+     ;; as it doesn't copy /etc/skel
+     (when create-home
+       (directory (fragment (user-home ~username)) :owner username)))
+
+   create-user (user username (merge
+                               {:create-home true :shell :bash}
+                               user-options))
+
+   :else (when create-home
+           (directory (fragment (user-home ~username)) :owner username))))
+
+(defplan create-admin
+  "Builds a user for use in remote-admin automation. The user is given
+permission to sudo without password, so that passwords don't have to appear
+in scripts, etc.
+
+`:username`
+: the username to create.  Defaults to the current admin user.
+
+`:public-key-paths`
+: a sequence of paths to public keys to be authorised on the user
+
+`:sudo`
+: a flag to add the user to sudoers.  Defaults to true.
+
+`:install-sudo`
+: a flag to install the sudoers package.  Defaults to true.
+
+`:create-user`
+: a flag to create the user.  Defaults to true if the user doesn't
+exist.
+
+`:create-home`
+: a flag to create the user's home directory.  Defauts to true.  When
+users are managed by, e.g.  LDAP, you may need to set this to false.
+
+`:user-options`
+: a map of options to pass to the `user` action when creating the
+user.
+"
+  [& {:keys [username public-key-paths sudo create-user create-home
+             install-sudo user-options]
+      :or {sudo true
+           install-sudo true
+           create-home ::unspecified
+           create-user ::unspecified}}]
+  (let [admin (admin-user)
+        username (or username (:username admin))
+        public-key-paths (or public-key-paths [(:public-key-path admin)])]
+    (when (and sudo install-sudo)
+      (sudoers/install))
+    (create-user-and-home username create-user create-home user-options)
+    (doseq [kp public-key-paths]
+      (authorize-user-key username kp))
+    (when sudo
+      (sudoers/sudoers
+       {}
+       {:default {:env_keep "SSH_AUTH_SOCK"}}
+       {username {:ALL {:run-as-user :ALL :tags :NOPASSWD}}}))))
+
+(defn server-spec
+  [{:keys [username public-key-paths sudo create-user create-home]
+    :as options}]
+  (api/server-spec
+   :phases {:bootstrap (plan-fn
+                        (package-manager :update)
+                        (apply-map create-admin options))}))
 
 (defplan automated-admin-user
   "Builds a user for use in remote-admin automation. The user is given
@@ -37,7 +121,7 @@
       {username {:ALL {:run-as-user :ALL :tags :NOPASSWD}}})))
 
 (def with-automated-admin-user
-  (server-spec
+  (api/server-spec
    :phases {:bootstrap (plan-fn
                           (package-manager :update)
                           (automated-admin-user))}))

--- a/test/pallet/crate/automated_admin_user_test.clj
+++ b/test/pallet/crate/automated_admin_user_test.clj
@@ -1,18 +1,22 @@
 (ns pallet.crate.automated-admin-user-test
   (:require
    [clojure.test :refer :all]
-   [pallet.actions :refer [exec-checked-script user]]
+   [pallet.actions :refer [directory exec-checked-script plan-when-not user]]
    [pallet.api :refer [lift make-user node-spec plan-fn server-spec]]
    [pallet.build-actions :as build-actions]
    [pallet.common.logging.logutils :refer [logging-threshold-fixture]]
    [pallet.context :as context]
    [pallet.context :as logging]
    [pallet.core.user :refer [default-public-key-path]]
+   [pallet.crate :refer [admin-user]]
    [pallet.crate.automated-admin-user :as automated-admin-user]
-   [pallet.crate.automated-admin-user :refer [automated-admin-user]]
+   [pallet.crate.automated-admin-user :refer [automated-admin-user
+                                              create-admin]]
    [pallet.crate.ssh-key :as ssh-key]
    [pallet.crate.sudoers :as sudoers]
-   [pallet.live-test :as live-test]))
+   [pallet.live-test :as live-test]
+   [pallet.script.lib :refer [user-home]]
+   [pallet.stevedore :refer [fragment]]))
 
 (use-fixtures :once (logging-threshold-fixture))
 
@@ -114,7 +118,31 @@
              (first
               (build-actions/build-actions
                   {:environment {:user (make-user user-name)}}
-               (automated-admin-user))))))))
+                  (automated-admin-user))))))))
+
+(deftest create-admin-test
+  (testing "with defaults"
+    (with-redefs [pallet.actions/plan-flag-kw (constantly :flagxxx)]
+      (is (script-no-comment=
+           (first
+            (build-actions/build-actions
+                {:phase-context "create-admin"}
+              (sudoers/install)
+              (plan-when-not (fragment ("getent" passwd fred))
+                (user "fred" :create-home true :shell :bash))
+              (directory (fragment (user-home fred)) :owner "fred")
+              (sudoers/sudoers
+               {}
+               {:default {:env_keep "SSH_AUTH_SOCK"}}
+               {"fred" {:ALL {:run-as-user :ALL :tags :NOPASSWD}}})
+              (context/with-phase-context
+                {:kw :authorize-user-key :msg "authorize-user-key"}
+                (ssh-key/authorize-key
+                 "fred" (slurp (default-public-key-path))))))
+           (first
+            (build-actions/build-actions
+                {}
+              (create-admin :username "fred"))))))))
 
 (deftest live-test
   ;; tests a node specific admin user
@@ -140,3 +168,28 @@
     (is
      (lift
       (val (first node-types)) :phase [:verify] :compute compute)))))
+
+(def create-admin-test-spec
+  (server-spec
+   :phases {:bootstrap (plan-fn
+                        (automated-admin-user/create-admin)
+                        (automated-admin-user/create-admin
+                         :username "xxx"
+                         :sudo false)
+                        (automated-admin-user/create-admin
+                         :username "yyy"
+                         :sudo false
+                         :user-options {:shell :sh}))
+            :verify (plan-fn
+                     (context/with-phase-context
+                       {:kw :automated-admin-user
+                        :msg "Check Automated admin user"}
+                       (exec-checked-script
+                        "is functional"
+                        (pipe (println @SUDO_USER)
+                              ("grep" ~(:username (admin-user))))
+                        (not ("grep" "xxx" "/etc/sudoers"))
+                        (user-home "xxx")
+                        (pipe
+                         ("getent" "yyy")
+                         (not ("grep" "bash"))))))}))


### PR DESCRIPTION
This is designed to replace the automated-admin-user function.  It is more
flexible, allowing suppression or forcing of adding the user to sudo, creation
of the user and the user's home directory.  It should work on systems using
pam_ldap and pam_mkhomedir.
