### PR TITLE
Create a package crate

### DIFF
--- a/src/pallet/action.clj
+++ b/src/pallet/action.clj
@@ -339,5 +339,5 @@ full action to do that."
 
 ;; Local Variables:
 ;; mode: clojure
-;; eval: (define-clojure-indent (clj-action 'defun))
+;; eval: (define-clojure-indent (clj-action 'defun) (implement-action 3))
 ;; End:

--- a/src/pallet/action_plan.clj
+++ b/src/pallet/action_plan.clj
@@ -711,7 +711,7 @@
                   (ffirst
                    ((domonad action-exec-m [v (m-map exec-action b)] v)
                     session)))
-        blocks (when (= 'pallet.actions-impl/if-action (:action-symbol action))
+        blocks (when (= 'pallet.actions.decl/if-action (:action-symbol action))
                  [(self-fn (first blocks) session)
                   (self-fn (second blocks) session)])]
     [(merge

--- a/src/pallet/actions/crate/package.clj
+++ b/src/pallet/actions/crate/package.clj
@@ -1,0 +1,338 @@
+(ns pallet.actions.crate.package
+  "Packages action implementation"
+  (:require
+   [clojure.string :as string]
+   [clojure.tools.logging :refer [tracef]]
+   [pallet.actions.decl
+    :refer [exec-checked-script package-source-changed-flag remote-file-action]]
+   [pallet.crate :refer [packager]]
+   [pallet.script.lib
+    :refer [file heredoc install-package list-installed-packages
+            package-manager-non-interactive purge-package os-version-name
+            upgrade-package remove-package rm update-package-list]]
+   [pallet.stevedore :refer [chain-commands* chained-script fragment script]]
+   [pallet.version-dispatch :refer [os-map os-map-lookup]]))
+
+;;; packages
+(defmulti adjust-packages
+  (fn [& _] (packager)))
+
+;; http://algebraicthunk.net/~dburrows/projects/aptitude/doc/en/ch02s03s01.html
+(def ^{:private true} aptitude-escape-map
+  {\+ "\\+"
+   \- "\\-"
+   \. "\\."
+   \( "\\"
+   \) "\\)"
+   \| "\\|"
+   \[ "\\["
+   \] "\\]"
+   \^ "\\^"
+   \$ "\\$"})
+
+;; aptitude and apt can install, remove and purge all in one command, so we just
+;; need to split by enable/disable options.
+(defmethod adjust-packages :aptitude
+  [packages]
+  (tracef "adjust-packages :aptitude %s" (vec packages))
+  (exec-checked-script
+   "Packages"
+   (package-manager-non-interactive)
+   (defn enableStart [] (rm "/usr/sbin/policy-rc.d"))
+   ~(chain-commands*
+     (for [[opts packages] (->>
+                            packages
+                            (group-by #(select-keys % [:enable :allow-unsigned
+                                                       :disable-service-start]))
+                            (sort-by #(apply min (map :priority (second %)))))]
+       (chained-script
+        ~(if (:disable-service-start opts)
+           (do
+             (script
+              (chain-and
+               ("trap" enableStart EXIT)
+               (heredoc "/usr/sbin/policy-rc.d" "#!/bin/sh\nexit 101" {}))))
+           "")
+        ("aptitude"
+         install -q -y
+         ~(string/join " " (map #(str "-t " %) (:enable opts)))
+         ~(if (:allow-unsigned opts)
+            "-o 'APT::Get::AllowUnauthenticated=true'"
+            "")
+         ~(string/join
+           " "
+           (for [[action packages] (group-by #(:action % :install) packages)
+                 {:keys [package force purge]} packages]
+             (case action
+               :install (format "%s+" package)
+               :remove (if purge
+                         (format "%s_" package)
+                         (format "%s-" package))
+               :upgrade (format "%s+" package)
+               (throw
+                (IllegalArgumentException.
+                 (str
+                  action " is not a valid action for package action")))))))
+        ~(if (:disable-service-start opts)
+           (do
+             (script
+              (chain-and
+               ("enableStart")
+               ("trap" - EXIT))))
+           ""))))
+   ;; aptitude doesn't report failed installed in its exit code
+   ;; so explicitly check for success
+   ~(chain-commands*
+     (for [{:keys [package action]} packages
+           :let [escaped-package (string/escape package aptitude-escape-map)]]
+       (cond
+        (#{:install :upgrade} action)
+        (script
+         (pipe ("aptitude"
+                search
+                (quoted
+                 (str "?and(?installed, ?name(^" ~escaped-package "$))")))
+               ("grep" (quoted ~package))))
+        (= :remove action)
+        (script
+         (not (pipe ("aptitude"
+                     search
+                     (quoted
+                      (str "?and(?installed, ?name(^" ~escaped-package "$))")))
+                    ("grep" (quoted ~package))))))))))
+
+(defmethod adjust-packages :apt
+  [packages]
+  (exec-checked-script
+   "Packages"
+   (package-manager-non-interactive)
+   (defn enableStart [] (rm "/usr/sbin/policy-rc.d"))
+   ~(chain-commands*
+     (for [[opts packages] (->>
+                            packages
+                            (group-by #(select-keys % [:enable :allow-unsigned
+                                                       :disable-service-start]))
+                            (sort-by #(apply min (map :priority (second %)))))]
+       (chained-script
+        ~(if (:disable-service-start opts)
+           (do
+             (script
+              (chain-and
+               ("trap" enableStart EXIT)
+               (heredoc "/usr/sbin/policy-rc.d" "#!/bin/sh\nexit 101" {}))))
+           "")
+        ("apt-get"
+         -q -y install
+         ~(string/join " " (map #(str "-t " %) (:enable opts)))
+         ~(if (:allow-unsigned opts) "--allow-unauthenticated" "")
+         ~(string/join
+           " "
+           (for [[action packages] (group-by #(:action % :install) packages)
+                 {:keys [package force purge]} packages]
+             (case action
+               :install (format "%s+" package)
+               :remove (if purge
+                         (format "%s_" package)
+                         (format "%s-" package))
+               :upgrade (format "%s+" package)
+               (throw
+                (IllegalArgumentException.
+                 (str (pr-str action)
+                      " is not a valid action for package action")))))))
+        ~(if (:disable-service-start opts)
+           (do
+             (script
+              (chain-and
+               ("enableStart")
+               ("trap" - EXIT))))
+           ""))))
+   (list-installed-packages)))
+
+(def ^{:private true :doc "Define the order of actions"}
+  action-order {:install 10 :remove 20 :upgrade 30})
+
+;; `yum` has separate install, remove and purge commands, so we just need to
+;; split by enable/disable options and by command.  We install before removing.
+(defmethod adjust-packages :yum
+  [packages]
+  (exec-checked-script
+   "Packages"
+   ~(chain-commands*
+     (conj
+      (vec
+       (for [[action packages] (->>
+                                packages
+                                (sort-by #(action-order (:action % :install)))
+                                (group-by #(:action % :install)))
+             [opts packages] (->>
+                              packages
+                              (group-by
+                               #(select-keys % [:enable :disable :exclude]))
+                              (sort-by
+                               #(apply min (map :priority (second %)))))]
+         (script
+          ("yum"
+           ~(name action) -q -y
+           ~(string/join " " (map #(str "--disablerepo=" %) (:disable opts)))
+           ~(string/join " " (map #(str "--enablerepo=" %) (:enable opts)))
+           ~(string/join " " (map #(str "--exclude=" %) (:exclude opts)))
+           ~(string/join
+             " "
+             (distinct (map :package packages)))))))
+      (list-installed-packages)))))
+
+(defmethod adjust-packages :default
+  [packages]
+  (exec-checked-script
+   "Packages"
+   (package-manager-non-interactive)
+   ~(chain-commands*
+     (for [[action packages] (group-by #(:action % :install) packages)
+           {:keys [package force purge]} packages]
+       (case action
+         :install (script (install-package ~package :force ~force))
+         :remove (if purge
+                   (script (purge-package ~package))
+                   (script (remove-package ~package)))
+         :upgrade (script (upgrade-package ~package))
+         (throw
+          (IllegalArgumentException.
+           (str action " is not a valid action for package action"))))))))
+
+(defn packages
+  "Install or remove packages.
+
+   Options
+    - :action [:install | :remove | :upgrade]
+    - :purge [true|false]          when removing, whether to remove all config
+    - :enable [repo|(seq repo)]    enable specific repository
+    - :disable [repo|(seq repo)]   disable specific repository
+    - :allow-unsigned [true|false] allow unsigned packages
+    - :disable-service-start       disable service startup (default false)
+
+   You probably want to use pallet.crate.package/package rather than
+   this action directly, which allows package management occurs in one
+   shot, so that the package manager can maintain a consistent view."
+  [packages & options]
+  (adjust-packages packages))
+
+;;; package-repository
+
+(def source-location
+  {:aptitude "/etc/apt/sources.list.d/%s.list"
+   :apt "/etc/apt/sources.list.d/%s.list"
+   :yum "/etc/yum.repos.d/%s.repo"})
+
+(defmulti format-source
+  "Format a package source definition"
+  (fn [packager & _] packager))
+
+(defmethod format-source :aptitude
+  [_ name options]
+  (format
+   "%s %s %s %s\n"
+   (:source-type options "deb")
+   (:url options)
+   (:release options (fragment (os-version-name)))
+   (string/join " " (:scopes options ["main"]))))
+
+(defmethod format-source :apt
+  [_ name options]
+  (format-source :aptitude name options))
+
+(defmethod format-source :yum
+  [_ name {:keys [url mirrorlist gpgcheck gpgkey priority failovermethod
+                  enabled]
+           :or {enabled 1}
+           :as options}]
+  (string/join
+   "\n"
+   (filter
+    identity
+    [(format "[%s]\nname=%s" name name)
+     (when url (format "baseurl=%s" url))
+     (when mirrorlist (format "mirrorlist=%s" mirrorlist))
+     (format "gpgcheck=%s" (or (and gpgkey 1) 0))
+     (when gpgkey (format "gpgkey=%s" gpgkey))
+     (when priority (format "priority=%s" priority))
+     (when failovermethod (format "failovermethod=%s" failovermethod))
+     (format "enabled=%s" enabled)
+     ""])))
+
+(def ^{:dynamic true} *default-apt-keyserver* "subkeys.pgp.net")
+
+(defmulti package-repository
+  "Add a package repository for the current packager.
+
+    - :priority n                  priority (0-100, default 50)
+"
+  (fn  [{:keys [repository] :as options}]
+    (packager)))
+
+(def ubuntu-ppa-add
+  (atom                                 ; allow for open extension
+   (os-map
+    {{:os :ubuntu :os-version [[10] [12 04]]} "python-software-properties"
+     {:os :ubuntu :os-version [[12 10] nil]} "software-properties-common"})))
+
+(defn- package-source-apt
+  [name {:keys [key-id key-server key-url url] :as options}]
+  (let [^String key-url url]
+    (if (and key-url (.startsWith key-url "ppa:"))
+      (let [list-file (str
+                       (string/replace (subs key-url 4) "/" "-")
+                       "-" (fragment (os-version-name)) ".list")]
+        (exec-checked-script
+         "Add ppa"
+         ~(if-let [package (os-map-lookup @ubuntu-ppa-add)]
+            (script
+             (chain-and
+              ("apt-cache" show ~package ">" "/dev/null") ; fail if unavailable
+              (install-package ~package))))
+         (when (not (file-exists? (file "/etc/apt/sources.list.d" ~list-file)))
+           (chain-and
+            (pipe (println "") ("add-apt-repository" ~key-url))
+            (update-package-list)))))
+      (remote-file-action
+       (format (source-location :apt) name)
+       {:content (format-source :apt name options)
+        :flag-on-changed package-source-changed-flag})))
+  (when key-id
+    (let [key-server (or key-server *default-apt-keyserver*)]
+      (exec-checked-script
+       "Install repository key from key server"
+       ("apt-key" adv "--keyserver" ~key-server "--recv-keys" ~key-id))))
+  (when key-url
+    (remote-file-action
+     "aptkey.tmp" {:url key-url :flag-on-changed package-source-changed-flag})
+    (exec-checked-script
+     "Install repository key"
+     ("apt-key" add aptkey.tmp))))
+
+(defmethod package-repository :aptitude
+  [{:keys [repository key-id key-server key-url url] :as options}]
+  (package-source-apt repository options))
+
+(defmethod package-repository :apt
+  [{:keys [repository key-id key-server key-url url] :as options}]
+  (package-source-apt repository options))
+
+(defmethod package-repository :yum
+  [{:keys [repository gpgkey] :as options}]
+  (remote-file-action
+   (format (source-location packager) repository)
+   {:content (format-source packager repository options)
+    :literal true
+    :flag-on-changed package-source-changed-flag})
+  (when gpgkey
+    (exec-checked-script
+     "Install repository key"
+     ("rpm" "--import" ~gpgkey))))
+
+(defmethod package-repository :default
+  [{:keys [repository] :as options}]
+  (let [packager (packager)]
+    (remote-file-action
+     (format (source-location packager) repository)
+     {:content (format-source packager repository options)
+      :flag-on-changed package-source-changed-flag})))

--- a/src/pallet/actions/decl.clj
+++ b/src/pallet/actions/decl.clj
@@ -1,0 +1,127 @@
+(ns pallet.actions.decl
+  "Action declarations"
+  (:require
+   [clojure.java.io :as io]
+   [pallet.action :refer [defaction]]
+   [pallet.action-plan :refer [checked-script]]
+   [pallet.actions-impl :refer :all]
+   [pallet.argument :as argument :refer [delayed delayed-argument?]]
+   [pallet.stevedore :as stevedore]))
+
+;;; # Direct Script Execution
+
+;;; Sometimes pallet's other actions will not suffice for what you would like to
+;;; achieve, so the exec-script actions allow you to execute arbitrary script.
+(defaction exec
+  "Execute script on the target node. The `script` is a plain string. `type`
+   specifies the script language (default :bash). You can override the
+   interpreter path using the `:interpreter` option."
+  [{:keys [language interpreter version] :or {language :bash}} script])
+
+
+(defaction exec-script*
+  "Execute script on the target node. The script is a plain string."
+  [script])
+
+(defmacro exec-script
+  "Execute a bash script remotely. The script is expressed in stevedore."
+  {:pallet/plan-fn true}
+  [& script]
+  `(exec-script* (delayed [_#] (stevedore/script ~@script))))
+
+(defmacro ^{:requires [#'checked-script]}
+  exec-checked-script
+  "Execute a bash script remotely, throwing if any element of the
+   script fails. The script is expressed in stevedore."
+  {:pallet/plan-fn true}
+  [script-name & script]
+  (let [file (.getName (io/file *file*))
+        line (:line (meta &form))]
+    `(exec-script*
+      (delayed [_#]
+               (checked-script
+                ~(if *script-location-info*
+                   `(str ~script-name " (" ~file ":" ~line ")")
+                   script-name)
+                ~@script)))))
+
+
+(defaction if-action
+  "An 'if' flow control action, that claims the next (up to two) nested scopes."
+  [condition])
+
+(defaction remote-file-action
+  "An action that implements most of remote-file, but requires a helper in order
+to deal with local file transfer."
+  [path {:keys [action url local-file
+                remote-file link content literal template values md5 md5-url
+                owner group mode force blob blobstore overwrite-changes
+                install-new-files no-versioning max-versions
+                flag-on-changed force insecure]
+         :or {action :create max-versions 5}
+         :as options}])
+
+
+(defaction remote-directory-action
+  [path {:keys [action url local-file remote-file
+                unpack tar-options unzip-options jar-options
+                strip-components md5 md5-url owner group recursive]
+         :or {action :create
+              tar-options "xz"
+              unzip-options "-o"
+              jar-options "xf"
+              strip-components 1
+              recursive true}
+         :as options}])
+
+(def package-source-changed-flag "packagesourcechanged")
+
+(defaction packages-action
+  "Install a list of packages."
+  [packager packages])
+
+(defaction package-repository-action
+  "Control package repository.
+   Options are a map of packager specific options.
+
+## aptitude and apt-get
+
+`:source-type source-string`
+: the source type (default \"deb\")
+
+`:url url-string`
+: the repository url
+
+`:scopes seq`
+: scopes to enable for repository
+
+`:release release-name`
+: override the release name
+
+`:key-url url-string`
+: url for key
+
+`:key-server hostname`
+: hostname to use as a keyserver
+
+`:key-id id`
+: id for key to look it up from keyserver
+
+## yum
+
+`:name name`
+: repository name
+
+`:url url-string`
+: repository base url
+
+`:gpgkey url-string`
+: gpg key url for repository
+
+## Example
+
+    (package-repository
+       {:repository-name \"Partner\"
+        :url \"http://archive.canonical.com/\"
+        :scopes [\"partner\"]})"
+  [packager {:as options}])

--- a/src/pallet/actions/direct/conditional.clj
+++ b/src/pallet/actions/direct/conditional.clj
@@ -2,7 +2,7 @@
   "Conditional action execution."
   (:require
    [pallet.action :refer [implement-action]]
-   [pallet.actions-impl :refer [if-action]]))
+   [pallet.actions.decl :refer [if-action]]))
 
 (implement-action if-action :direct
   {:action-type :flow/if :location :origin}

--- a/src/pallet/actions/direct/exec_script.clj
+++ b/src/pallet/actions/direct/exec_script.clj
@@ -2,7 +2,7 @@
   "Script execution. Script generation occurs with the correct script context."
   (:require
    [pallet.action :refer [implement-action]]
-   [pallet.actions :refer [exec exec-script*]]))
+   [pallet.actions.decl :refer [exec exec-script*]]))
 
 (implement-action exec :direct
   {:action-type :script :location :target}

--- a/src/pallet/actions/direct/package.clj
+++ b/src/pallet/actions/direct/package.clj
@@ -19,7 +19,9 @@
             package-source
             package-source-changed-flag
             sed]]
-   [pallet.actions-impl :refer [remote-file-action]]
+   [pallet.actions.decl :refer [remote-file-action
+                                packages-action
+                                package-repository-action]]
    [pallet.core.session :refer [os-family packager]]
    [pallet.script.lib :as lib]
    [pallet.stevedore :as stevedore]
@@ -31,6 +33,7 @@
 
 (def ^{:private true}
   remote-file* (action-fn remote-file-action :direct))
+
 (def ^{:private true}
   sed* (action-fn sed :direct))
 
@@ -428,6 +431,14 @@
      :summary (str "package-source " (string/join " " (map vec args)))}
     (stevedore/do-script*
      (map (fn [x] (apply package-source* session x)) args))]
+   session])
+
+(implement-action package-repository-action :direct
+                  {:action-type :script :location :target}
+  [session options]
+  [[{:language :bash
+     :summary (str "package-repository " (:repository-name options))}
+    (package-source* session options)]
    session])
 
 (defn add-scope*

--- a/src/pallet/actions/direct/remote_directory.clj
+++ b/src/pallet/actions/direct/remote_directory.clj
@@ -7,10 +7,8 @@
    [pallet.action-plan :refer [checked-commands]]
    [pallet.actions :refer [directory]]
    [pallet.actions-impl
-    :refer [md5-filename
-            new-filename
-            remote-directory-action
-            remote-file-action]]
+    :refer [md5-filename new-filename]]
+   [pallet.actions.decl :refer [remote-directory-action remote-file-action]]
    [pallet.actions.direct.remote-file :refer [create-path-with-template]]
    [pallet.script.lib :as lib :refer [user-default-group]]
    [pallet.stevedore :as stevedore :refer [fragment]]

--- a/src/pallet/actions/direct/remote_file.clj
+++ b/src/pallet/actions/direct/remote_file.clj
@@ -11,8 +11,8 @@
             transfer-file
             transfer-file-to-local
             wait-for-file]]
-   [pallet.actions-impl
-    :refer [copy-filename md5-filename new-filename remote-file-action]]
+   [pallet.actions-impl :refer [copy-filename md5-filename new-filename]]
+   [pallet.actions.decl :refer [remote-file-action]]
    [pallet.actions.direct.file :as file]
    [pallet.blobstore :as blobstore]
    [pallet.environment-impl :refer [get-for]]

--- a/src/pallet/actions_impl.clj
+++ b/src/pallet/actions_impl.clj
@@ -3,7 +3,6 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as string]
-   [pallet.action :refer [defaction]]
    [pallet.common.context :refer [throw-map]]
    [pallet.context :as context]
    [pallet.core.session :refer [session]]
@@ -13,10 +12,6 @@
    [pallet.stevedore :refer [fragment script]]))
 
 (def ^:dynamic *script-location-info* true)
-
-(defaction if-action
-  "An 'if' flow control action, that claims the next (up to two) nested scopes."
-  [condition])
 
 (defn verify-local-file-exists
   [local-file]
@@ -37,30 +32,6 @@
              nodes."
        :dynamic true}
   *force-overwrite* false)
-
-(defaction remote-file-action
-  "An action that implements most of remote-file, but requires a helper in order
-to deal with local file transfer."
-  [path {:keys [action url local-file
-                remote-file link content literal template values md5 md5-url
-                owner group mode force blob blobstore overwrite-changes
-                install-new-files no-versioning max-versions
-                flag-on-changed force insecure]
-         :or {action :create max-versions 5}
-         :as options}])
-
-
-(defaction remote-directory-action
-  [path {:keys [action url local-file remote-file
-                unpack tar-options unzip-options jar-options
-                strip-components md5 md5-url owner group recursive]
-         :or {action :create
-              tar-options "xz"
-              unzip-options "-o"
-              jar-options "xf"
-              strip-components 1
-              recursive true}
-         :as options}])
 
 (defn init-script-path
   "Path to the specified initd script"

--- a/src/pallet/crate/package.clj
+++ b/src/pallet/crate/package.clj
@@ -1,0 +1,84 @@
+(ns pallet.crate.package
+  "A crate to control packages on a remote node."
+  (:require
+   [clj-schema.schema :refer [def-map-schema optional-path sequence-of wild]]
+   ;; [pallet.contracts :refer []]
+   [pallet.api :as api]
+   [pallet.actions :as actions]
+   [pallet.crate :refer [defplan get-settings packager update-settings]]))
+
+(def-map-schema package-repo-schema
+  [[:repository] String
+   (optional-path [:enable]) wild
+   (optional-path [:priority]) number?])
+
+(def-map-schema package-schema
+  [[:package] String                        ; package name
+   (optional-path [:allow-unsigned]) String ; flag to allow unsigned pkg
+   (optional-path [:repository]) String     ; an optional repository
+   (optional-path [:version]) String    ; an optional exact version
+   (optional-path [:disable-service-start]) wild]) ; flag to disable
+                                        ; service startup
+
+(def-map-schema package-settings-schema
+  [[:packages] (sequence-of package-schema)
+   [:package-repositories] (sequence-of package-repo-schema)])
+
+(defn- conj-distinct
+  [coll arg]
+  (vec (distinct (conj (or coll []) arg))))
+
+(defn package*
+  "Add a package to the packages list."
+  [{:keys [package-name repository version] :as pkg}
+   {:keys [instance-id] :as options}]
+  (update-settings ::packages options update-in [:packages] conj-distinct pkg))
+
+(defn package
+  "Add a package to the packages list."
+  [package-name & {:keys [repository version instance-id] :as options}]
+  (package*
+   (assoc (dissoc options :instance-id) :package package-name)
+   (select-keys options [:instance-id])))
+
+(defn package-repository*
+  "Add a package repository to the packages list."
+  [{:keys [repository enable] :as repo} {:keys [instance-id] :as options}]
+  (update-settings
+   ::packages options update-in [:package-repositories] conj-distinct repo))
+
+(defn package-repository
+  "Add a package repository to the packages list."
+  [repository {:keys [instance-id] :as options}]
+  (package-repository*
+   (assoc (dissoc options :instance-id) :repository repository)
+   (select-keys options [:instance-id])))
+
+(defplan settings
+  "Initialise package repositories and packages to be installed."
+  [{:keys [packages package-repositories instance-id] :as options}]
+  (doseq [repo package-repositories]
+    (package-repository* repo (select-keys options [:instance-id])))
+  (doseq [pkg packages]
+    (package* pkg (select-keys options [:instance-id]))))
+
+(defn install
+  "Install package repositories and packages."
+  [{:keys [instance-id]}]
+  (let [{:keys [packages package-repositories]}
+        (get-settings ::packages)]
+    (doseq [repo package-repositories]
+      (actions/package-repository repo))
+    ;; TODO automatic package manager update of changed repo defintions
+    (when (seq packages)
+      (actions/all-packages packages))))
+
+(defn server-spec
+  "Return a server spec that will install packages, as specified
+by calls to `package` and `package-repository`"
+  [{:keys [packages package-repositories instance-id] :as options}]
+  (api/server-spec
+   :phases {:settings (api/plan-fn
+                       (settings options))
+            :install (api/plan-fn
+                      (install (select-keys options [:instance-id])))}))

--- a/src/pallet/crate/package/rpmforge.clj
+++ b/src/pallet/crate/package/rpmforge.clj
@@ -3,7 +3,7 @@
   (:require
    [pallet.action :refer [action-fn with-action-options]]
    [pallet.actions :refer [exec-checked-script package package-manager]]
-   [pallet.actions-impl :refer [remote-file-action]]
+   [pallet.actions.decl :refer [remote-file-action]]
    [pallet.core.session :refer [session]]
    [pallet.crate :refer [defplan]]))
 

--- a/src/pallet/executors.clj
+++ b/src/pallet/executors.clj
@@ -131,7 +131,7 @@
         exec-action (session-exec-action session)
         self-fn (fn [b session]
                   (first (map-action-f exec-action b session)))
-        blocks (when (= 'pallet.actions-impl/if-action action-symbol)
+        blocks (when (= 'pallet.actions.decl/if-action action-symbol)
                  [(self-fn (first blocks) session)
                   (self-fn (second blocks) session)])]
     [(merge

--- a/test/pallet/actions/crate/package_test.clj
+++ b/test/pallet/actions/crate/package_test.clj
@@ -1,0 +1,39 @@
+(ns pallet.actions.crate.package-test
+  (:require
+   [clojure.test :refer :all]
+   [pallet.actions :refer [exec-checked-script]]
+   [pallet.actions.crate.package :refer [packages package-repository]]
+   [pallet.actions.decl :refer [remote-file-action]]
+   [pallet.build-actions :refer [build-actions]]
+   [pallet.script.lib :refer [package-manager-non-interactive rm]]))
+
+(deftest packages-test
+  (is (script-no-comment=
+       (first
+        (build-actions
+            {}
+          (exec-checked-script
+           "Packages"
+           (package-manager-non-interactive)
+           (chain-and
+            (defn enableStart [] (rm "/usr/sbin/policy-rc.d"))
+            "apt-get -q -y install git+ ruby+"
+            ("dpkg" "--get-selections")))))
+       (first
+        (build-actions {:server {:tag :n :image {:os-family :ubuntu}}}
+          (packages [{:package "git"}{:package "ruby"}]))))))
+
+(deftest package-repository-test
+  (is (script-no-comment=
+       (first
+        (build-actions {}
+          (remote-file-action
+           "/etc/apt/sources.list.d/source1.list"
+           {:content "deb http://somewhere/apt $(lsb_release -c -s) main\n"
+            :flag-on-changed "packagesourcechanged"})))
+       (first
+        (build-actions {:server {:tag :n :image {:os-family :ubuntu}}}
+          (package-repository
+           {:repository "source1"
+            :url "http://somewhere/apt"
+            :scopes ["main"]}))))))

--- a/test/pallet/actions/direct/conditional_test.clj
+++ b/test/pallet/actions/direct/conditional_test.clj
@@ -64,9 +64,9 @@
               op (lift
                   (group-spec "local")
                   :phase (plan-fn
-                           (exec-script ("touch" (quoted ~(.getPath tmp))))
-                           (plan-when (script (file-exists? ~(.getPath tmp)))
-                             (exec-script (println "tmp found"))))
+                          (exec-script ("touch" (quoted ~(.getPath tmp))))
+                          (plan-when (script (file-exists? ~(.getPath tmp)))
+                            (exec-script (println "tmp found"))))
                   :compute compute
                   :user (local-test-user)
                   :async true)

--- a/test/pallet/actions/direct/exec_script_test.clj
+++ b/test/pallet/actions/direct/exec_script_test.clj
@@ -41,11 +41,10 @@
 
 (deftest exec-script*-test
   (let [v (promise)
-        rv (let-actions
-            {}
-            (let [nv (exec-script* "ls file1")]
-              (deliver v nv)
-              nv))]
+        rv (let-actions {}
+             (let [nv (exec-script* "ls file1")]
+               (deliver v nv)
+               nv))]
     (is (= "ls file1\n" (first rv)))
     (is (= [{:language :bash} "ls file1"] (node-value @v (second rv))))))
 
@@ -76,10 +75,9 @@
               (exec-checked-script "check" (~ls "file1")))))))))
 
 (deftest exec-test
-  (let [rv (let-actions
-            {}
-            (let [nv (exec {:language :python} "print 'Hello, world!'")]
-              nv))]
+  (let [rv (let-actions {}
+             (let [nv (exec {:language :python} "print 'Hello, world!'")]
+               nv))]
     (is (= "print 'Hello, world!'\n" (first rv)))))
 
 (def print-action

--- a/test/pallet/actions/direct/package_test.clj
+++ b/test/pallet/actions/direct/package_test.clj
@@ -13,7 +13,7 @@
             packages
             remote-file
             sed]]
-   [pallet.actions-impl :refer [remote-file-action]]
+   [pallet.actions.decl :refer [remote-file-action]]
    [pallet.actions.direct.package
     :refer [add-scope* adjust-packages package-manager* package-source*]]
    [pallet.api :refer [group-spec]]

--- a/test/pallet/actions/direct/remote_directory_test.clj
+++ b/test/pallet/actions/direct/remote_directory_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer :all]
    [pallet.action :refer [action-fn]]
    [pallet.actions :refer [directory remote-directory]]
-   [pallet.actions-impl :refer [remote-file-action]]
+   [pallet.actions.decl :refer [remote-file-action]]
    [pallet.actions.direct.remote-file :refer [create-path-with-template]]
    [pallet.build-actions :as build-actions]
    [pallet.common.logging.logutils :refer [logging-threshold-fixture]]

--- a/test/pallet/actions/direct/remote_file_test.clj
+++ b/test/pallet/actions/direct/remote_file_test.clj
@@ -14,8 +14,8 @@
             transfer-file-to-local
             with-action-values
             with-remote-file]]
-   [pallet.actions-impl
-    :refer [copy-filename md5-filename new-filename remote-file-action]]
+   [pallet.actions-impl :refer [copy-filename md5-filename new-filename]]
+   [pallet.actions.decl :refer [remote-file-action]]
    [pallet.actions.direct.remote-file :refer [create-path-with-template]]
    [pallet.algo.fsmop :refer [complete? failed? wait-for]]
    [pallet.api :refer [group-spec lift plan-fn with-admin-user]]

--- a/test/pallet/build_actions.clj
+++ b/test/pallet/build_actions.clj
@@ -145,5 +145,5 @@
 
 ;; Local Variables:
 ;; mode: clojure
-;; eval: (define-clojure-indent (build-actions 1))
+;; eval: (define-clojure-indent (build-actions 1)(let-actions 1))
 ;; End:

--- a/test/pallet/crate/etc_default_test.clj
+++ b/test/pallet/crate/etc_default_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer :all]
    [pallet.action :refer [action-fn]]
    [pallet.actions :refer [remote-file]]
-   [pallet.actions-impl :refer [remote-file-action]]
+   [pallet.actions.decl :refer [remote-file-action]]
    [pallet.build-actions :refer [build-actions]]
    [pallet.common.logging.logutils :refer [logging-threshold-fixture]]
    [pallet.crate :refer [phase-context]]

--- a/test/pallet/crate/package_test.clj
+++ b/test/pallet/crate/package_test.clj
@@ -1,0 +1,40 @@
+(ns pallet.crate.package-test
+  (:require
+   [clojure.test :refer :all]
+   [pallet.actions :refer [exec-checked-script]]
+   [pallet.crate.package :refer [install package package-repository]]
+   [pallet.actions.decl :refer [remote-file-action]]
+   [pallet.build-actions :refer [build-actions]]
+   [pallet.script.lib :refer [package-manager-non-interactive rm]]))
+
+(deftest packages-test
+  (is (script-no-comment=
+       (first
+        (build-actions {}
+          (exec-checked-script
+           "Packages"
+           (package-manager-non-interactive)
+           (chain-and
+            (defn enableStart [] (rm "/usr/sbin/policy-rc.d"))
+            "apt-get -q -y install git+ ruby+"
+            ("dpkg" "--get-selections")))))
+       (first
+        (build-actions {:server {:tag :n :image {:os-family :ubuntu}}}
+          (package "git")
+          (package "ruby")
+          (install {}))))))
+
+(deftest package-repository-test
+  (is (script-no-comment=
+       (first
+        (build-actions {}
+          (remote-file-action
+           "/etc/apt/sources.list.d/source1.list"
+           {:content "deb http://somewhere/apt $(lsb_release -c -s) main\n"
+            :flag-on-changed "packagesourcechanged"})))
+       (first
+        (build-actions {:server {:tag :n :image {:os-family :ubuntu}}}
+          (package-repository
+           "source1"
+           {:url "http://somewhere/apt" :scopes ["main"]})
+          (install {}))))))

--- a/test/pallet/executors_test.clj
+++ b/test/pallet/executors_test.clj
@@ -27,12 +27,12 @@
             :summary nil
             :action-type :script
             :script [{:language :bash} "f"]
-            :form (pallet.actions/exec-script* "f")
+            :form (pallet.actions.decl/exec-script* "f")
             :context nil
             :args ["f"]
-            :action-symbol pallet.actions/exec-script*,
+            :action-symbol pallet.actions.decl/exec-script*,
             :action
-            {:action-symbol pallet.actions/exec-script*,
+            {:action-symbol pallet.actions.decl/exec-script*,
              :execution :in-sequence
              :precedence {}}})
          (plan-data-fn (plan-fn (exec-script "f")))))
@@ -40,29 +40,29 @@
             :summary nil
             :action-type :flow/if,
             :script true,
-            :form (pallet.actions-impl/if-action
+            :form (pallet.actions.decl/if-action
                    true
-                   [(pallet.actions/exec-script* "f")]
+                   [(pallet.actions.decl/exec-script* "f")]
                    []),
             :blocks
             [[{:location :target,
                :action-type :script,
                :script [{:language :bash} "f"],
                :summary nil
-               :form (pallet.actions/exec-script* "f"),
+               :form (pallet.actions.decl/exec-script* "f"),
                :context ("plan-when"),
                :args ("f"),
-               :action-symbol pallet.actions/exec-script*,
+               :action-symbol pallet.actions.decl/exec-script*,
                :action
-               {:action-symbol pallet.actions/exec-script*,
+               {:action-symbol pallet.actions.decl/exec-script*,
                 :execution :in-sequence,
                 :precedence {}}}]
              []],
             :context ("plan-when"),
             :args (true),
-            :action-symbol pallet.actions-impl/if-action,
+            :action-symbol pallet.actions.decl/if-action,
             :action
-            {:action-symbol pallet.actions-impl/if-action,
+            {:action-symbol pallet.actions.decl/if-action,
              :execution :in-sequence,
              :precedence {}}})
          (plan-data-fn (plan-fn
@@ -73,29 +73,29 @@
             :action-type :flow/if,
             :script true,
             :form
-            (pallet.actions-impl/if-action
+            (pallet.actions.decl/if-action
              true
              []
-             [(pallet.actions/exec-script* "g")]),
+             [(pallet.actions.decl/exec-script* "g")]),
             :blocks
             [[]
              [{:location :target,
                :action-type :script,
                :script [{:language :bash} "g"],
                :summary nil
-               :form (pallet.actions/exec-script* "g"),
+               :form (pallet.actions.decl/exec-script* "g"),
                :context ("plan-when-not"),
                :args ("g"),
-               :action-symbol pallet.actions/exec-script*,
+               :action-symbol pallet.actions.decl/exec-script*,
                :action
-               {:action-symbol pallet.actions/exec-script*,
+               {:action-symbol pallet.actions.decl/exec-script*,
                 :execution :in-sequence,
                 :precedence {}}}]],
             :context ("plan-when-not"),
             :args (true),
-            :action-symbol pallet.actions-impl/if-action,
+            :action-symbol pallet.actions.decl/if-action,
             :action
-            {:action-symbol pallet.actions-impl/if-action,
+            {:action-symbol pallet.actions.decl/if-action,
              :execution :in-sequence,
              :precedence {}}})
          (plan-data-fn (plan-fn
@@ -106,12 +106,12 @@
              :summary nil
              :action-type :script,
              :script [{:language :bash} "g"],
-             :form (pallet.actions/exec-script* "g"),
+             :form (pallet.actions.decl/exec-script* "g"),
              :context nil,
              :args ("g"),
-             :action-symbol pallet.actions/exec-script*,
+             :action-symbol pallet.actions.decl/exec-script*,
              :action
-             {:action-symbol pallet.actions/exec-script*,
+             {:action-symbol pallet.actions.decl/exec-script*,
               :execution :in-sequence,
               :precedence {}},
              :script-dir "abc",}
@@ -125,7 +125,7 @@
              :sudo-user nil
              :script-prefix :sudo,
              :action-type :script,
-             :form (pallet.actions-impl/remote-file-action
+             :form (pallet.actions.decl/remote-file-action
                     "p"
                     {:content "line 1\nline 2",
                      :install-new-files true,
@@ -137,9 +137,9 @@
                      :install-new-files true,
                      :overwrite-changes nil,
                      :owner nil}),
-             :action-symbol pallet.actions-impl/remote-file-action
+             :action-symbol pallet.actions.decl/remote-file-action
              :action
-             {:action-symbol pallet.actions-impl/remote-file-action
+             {:action-symbol pallet.actions.decl/remote-file-action
               :execution :in-sequence,
               :precedence {}}
              :summary "remote-file p :content \"line 1...\""}


### PR DESCRIPTION
Create a package crate and new packages and package-repository actions.  The
actions and crate do not use action precedence, or accumulated actions.

The aim here is to deprecate the package and package-source actions,
replacing them with packages and package-repository actions.

The new actions are used via the new package crate, which uses
settings to aggregate the packages, rather than using the action plan.
