### PR TITLE
Replaced readlink with canonical-path in remote-directory

### DIFF
--- a/src/pallet/actions/direct/remote_directory.clj
+++ b/src/pallet/actions/direct/remote_directory.clj
@@ -91,7 +91,7 @@
                         ~(condp = unpack
                           :tar (stevedore/checked-script
                                 (format "Untar %s" tarpath)
-                                (var rdf @("readlink" -f ~tarpath))
+                                (var rdf @(lib/canonical-path ~tarpath))
                                 ("cd" ~path)
                                 ("tar"
                                  ~tar-options
@@ -101,13 +101,13 @@
                                 ("cd" -))
                           :unzip (stevedore/checked-script
                                   (format "Unzip %s" tarpath)
-                                  (var rdf @("readlink" -f ~tarpath))
+                                  (var rdf @(lib/canonical-path ~tarpath))
                                   ("cd" ~path)
                                   ("unzip" ~unzip-options @rdf ~extract-files)
                                   ("cd" -))
                           :jar (stevedore/checked-script
                                 (format "Unjar %s" tarpath)
-                                (var rdf @("readlink" -f ~tarpath))
+                                (var rdf @(lib/canonical-path ~tarpath))
                                 ("cd" ~path)
                                 ("jar" ~jar-options @rdf ~extract-files)
                                 ("cd" -)))


### PR DESCRIPTION
readlink -f doesn't work on mac os-x. canonical-path provides the correct abstraction.
