### PR TITLE
Correctly wire 'partition-f' parameter in partitioning logic.

### DIFF
--- a/src/pallet/core/operations.clj
+++ b/src/pallet/core/operations.clj
@@ -197,7 +197,8 @@ to the correct targets in lift."
      targets
      (clojure.core/partition-by fns)
      (mapcat
-      #(let [[pf & _] (fns (first %))]
+      #(let [[pf & _] (fns (first %))
+             pf       (or f pf)]
          (if pf
            (pf %)
            [%]))))))


### PR DESCRIPTION
Hi there,

This PR adds the logic to correctly handle `:partition-f` parameter of `pallet.api/lift` during partitioning of targets. I wonder if `:post-phase-f` and `:post-phase-fsm` parameters passed to `lift` should be handled there too. wdyt?

David
