### PR TITLE
Rename nodes-with-roles to targets-with-nodes and add nodes-with-role in pallet.crate

### DIFF
--- a/src/pallet/core/session.clj
+++ b/src/pallet/core/session.clj
@@ -157,7 +157,6 @@
          (when-let [group-names (:group-names %)] (group-names group-name))))
    (map :node)))
 
-
 (defn groups-with-role
   "All target groups with the specified role."
   [session role]
@@ -167,14 +166,19 @@
    (map #(dissoc % :node))
    distinct))
 
-(defn nodes-with-role
-  "All target nodes with the specified role."
+(defn targets-with-role
+  "All targets with the specified role."
   [session role]
   (filter
    (fn [node]
      (when-let [roles (:roles node)]
        (roles role)))
    (:service-state session)))
+
+(defn nodes-with-role
+  "All target nodes with the specified role."
+  [session role]
+  (map :node (targets-with-role session role)))
 
 (defn role->nodes-map
   "Returns a map from role to nodes."

--- a/src/pallet/crate.clj
+++ b/src/pallet/crate.clj
@@ -246,6 +246,11 @@
   [role]
   (session/groups-with-role (session) role))
 
+(defn targets-with-role
+  "All targets with the specified role."
+  [role]
+  (session/targets-with-role (session) role))
+
 (defn nodes-with-role
   "All target nodes with the specified role."
   [role]

--- a/test/pallet/crate_test.clj
+++ b/test/pallet/crate_test.clj
@@ -23,9 +23,20 @@
         g2 (group-spec "group2" :roles :role2)
         targets [(assoc g1 :node n1) (assoc g2 :node n2)]
         session (test-session {:service-state targets})]
-    (is (= [(first targets)]
+    (is (= [n1]
            (with-session session
              (nodes-with-role :role1))))))
+
+(deftest targets-with-role-test
+  (let [n1 (make-node "group1")
+        n2 (make-node "group2")
+        g1 (group-spec "group1" :roles :role1)
+        g2 (group-spec "group2" :roles :role2)
+        targets [(assoc g1 :node n1) (assoc g2 :node n2)]
+        session (test-session {:service-state targets})]
+    (is (= [(first targets)]
+           (with-session session
+             (targets-with-role :role1))))))
 
 (defmulti-plan xx
   (fn [k]


### PR DESCRIPTION
Actually, nodes-with-roles is misleading as it returns targets instead of nodes. This PR renames it to targets-with-role and adds nodes-with-role, which returns nodes as expected.
