### PR TITLE
Add a create-only flag to remote-file

### DIFF
--- a/src/pallet/actions.clj
+++ b/src/pallet/actions.clj
@@ -285,7 +285,8 @@ value is itself an action return value."
   ^{:doc "A vector of options for controlling versions. Can be used for option
           forwarding when calling remote-file from other crates."}
   version-options
-  [:overwrite-changes :no-versioning :max-versions :flag-on-changed])
+  [:overwrite-changes :no-versioning :max-versions :flag-on-changed
+   :create-only])
 
 (def
   ^{:doc "A vector of options for controlling ownership. Can be used for option
@@ -327,7 +328,8 @@ value is itself an action return value."
    (optional-path [:force]) any-value
    (optional-path [:link]) String
    (optional-path [:verify]) any-value
-   (optional-path [::upload-path]) String])
+   (optional-path [::upload-path]) String
+   (optional-path [::create-only]) any-value])
 
 (defmacro check-remote-file-arguments
   [m]
@@ -425,6 +427,10 @@ Options for version control are:
 `flag-on-changed`
 : flag to set if file is changed
 
+`create-only`
+: boolean flag to specify that the target file should only be
+  created. If the file already exists, it is not touched.
+
 Options for specifying the file's permissions are:
 
 `owner`
@@ -481,7 +487,8 @@ Content can also be copied from a blobstore.
                   overwrite-changes no-versioning max-versions
                   flag-on-changed
                   local-file-options
-                  verify]
+                  verify
+                  create-only]
            :as options}]
   {:pre [path]}
   (check-remote-file-arguments options)

--- a/src/pallet/actions/direct/remote_file.clj
+++ b/src/pallet/actions/direct/remote_file.clj
@@ -93,7 +93,8 @@
                                         flag-on-changed
                                         force
                                         insecure
-                                        verify]
+                                        verify
+                                        create-only]
                                  :or {action :create max-versions 5
                                       install-new-files true}
                                  :as options}]
@@ -125,6 +126,12 @@
         :create
         (action-plan/checked-commands
          (str "remote-file " path)
+
+         (if create-only
+           (stevedore/script
+            (if (file-exists? ~path)
+              (exit 0)))
+           "")
 
          ;; check for local modifications
          (if overwrite-changes


### PR DESCRIPTION
The create-only flag can be used to create a remote-file only if that remote
file doesn't exist.  The use case for this is to be able to create
configuration files and allow them to be edited on the target node without
being overwritten.
