### PR TITLE
Fix silent failures of chown in state-root

### DIFF
--- a/src/pallet/ssh/node_state/state_root.clj
+++ b/src/pallet/ssh/node_state/state_root.clj
@@ -52,76 +52,76 @@
 permissions. Note this is not the final directory."
   [template-path new-path]
   (script
-   (": ")
-   ("#" "-- START pallet implementation function")
-   (defn set_tree_permissions [template_path new_path]
-     (set! dirpath @(dirname @new_path))
-     (set! templatepath @(dirname @(if (file-exists? @template_path)
-                                     (canonical-path @template_path)
-                                     (println @template_path))))
-     (when (not (directory? @templatepath))
-       (println @templatepath ": Directory does not exist.")
-       (exit 1))
-     (set! templatepath @(canonical-path @templatepath))
-     (chain-or (mkdir @dirpath :path true) (exit 1))
-     ("while" (!= "/" @templatepath) ";do"
-      ~(chained-script
-        (set! d @dirpath)        ; copy these and update
-        (set! t @templatepath)   ; so we can continue on any failure
-        (when (not (directory? @templatepath))
-          (println @templatepath ": Directory does not exist.")
-          (exit 1))
-        (set! dirpath @(dirname @dirpath))
-        (set! templatepath @(dirname @templatepath))
-        (if (not (== @(path-group @t) @(path-group @d)))
-          (chgrp @(path-group @t) @d))
-        (if (not (== @(path-mode @t) @(path-mode @d)))
-          (chmod @(path-mode @t) @d))
-        (if (not (== @(path-owner @t) @(path-owner @d)))
-          (chown @(path-owner @t) @d)))
-      ("; done")))
-   ("#" "-- END pallet implementation function")
-   ("set_tree_permissions" ~template-path ~new-path)))
+   (group
+    ("#" "-- START pallet implementation function\n")
+    (defn set_tree_permissions [template_path new_path]
+      (set! dirpath @(dirname @new_path))
+      (set! templatepath @(dirname @(if (file-exists? @template_path)
+                                      (canonical-path @template_path)
+                                      (println @template_path))))
+      (when (not (directory? @templatepath))
+        (println @templatepath ": Directory does not exist.")
+        (exit 1))
+      (set! templatepath @(canonical-path @templatepath))
+      (chain-or (mkdir @dirpath :path true) (exit 1))
+      ("while" (!= "/" @templatepath) ";do"
+       ~(chained-script
+         (set! d @dirpath)        ; copy these and update
+         (set! t @templatepath)   ; so we can continue on any failure
+         (when (not (directory? @templatepath))
+           (println @templatepath ": Directory does not exist.")
+           (exit 1))
+         (set! dirpath @(dirname @dirpath))
+         (set! templatepath @(dirname @templatepath))
+         (if (not (== @(path-group @t) @(path-group @d)))
+           (chgrp @(path-group @t) @d))
+         (if (not (== @(path-mode @t) @(path-mode @d)))
+           (chmod @(path-mode @t) @d))
+         (if (not (== @(path-owner @t) @(path-owner @d)))
+           (chown @(path-owner @t) @d)))
+       ("; done")))
+    ("#" "-- END pallet implementation function\n")
+    ("set_tree_permissions" ~template-path ~new-path))))
 
 (defn verify
   "verify if the files at path and state-path are identical, and
   whether they match the md5-path."
   [path state-path md5-path]
   (script
-   (": ")
-   ("#" "-- START pallet implementation function")
-   (defn verify_md5 [path state_path md5_path]
-     (chain-and
-      ;; check if the file and the current copy are the same
-      (var filediff "")
-      (if (&& (file-exists? @path) (file-exists? @state_path))
-        (do
-          (diff @path @state_path :unified true)
-          (set! filediff "$?")))
-      ;; check if the current copy and the md5 match
-      (var md5diff "")
-      (if (&& (file-exists? @state_path) (file-exists? @md5_path))
-        (do
-          (md5sum-verify @md5_path)
-          (set! md5diff "$?")))
+   (group
+    ("#" "-- START pallet implementation function\n")
+    (defn verify_md5 [path state_path md5_path]
+      (chain-and
+       ;; check if the file and the current copy are the same
+       (var filediff "")
+       (if (&& (file-exists? @path) (file-exists? @state_path))
+         (do
+           (diff @path @state_path :unified true)
+           (set! filediff "$?")))
+       ;; check if the current copy and the md5 match
+       (var md5diff "")
+       (if (&& (file-exists? @state_path) (file-exists? @md5_path))
+         (do
+           (md5sum-verify @md5_path)
+           (set! md5diff "$?")))
 
-      ;; report any errors
-      (var errexit 0)
-      (if (== @filediff 1)
-        (do
-          (println
-           "Existing file did not match the pallet master copy: FAIL")
-          (set! errexit 1)))
+       ;; report any errors
+       (var errexit 0)
+       (if (== @filediff 1)
+         (do
+           (println
+            "Existing file did not match the pallet master copy: FAIL")
+           (set! errexit 1)))
 
-      (if (== @md5diff 1)
-        (do
-          (println "Existing content did not match md5: FAIL")
-          (set! errexit 1)))
+       (if (== @md5diff 1)
+         (do
+           (println "Existing content did not match md5: FAIL")
+           (set! errexit 1)))
 
-      ;; exit if error
-      (== @errexit 0)))
-   ("#" "-- END pallet implementation function")
-   ("verify_md5" ~path ~state-path ~md5-path)))
+       ;; exit if error
+       (== @errexit 0)))
+    ("#" "-- END pallet implementation function\n")
+    ("verify_md5" ~path ~state-path ~md5-path))))
 
 (defn record
   "Script to record a new (version of a) file in state-root"
@@ -129,47 +129,47 @@ permissions. Note this is not the final directory."
                     :or {max-versions 5
                          versioning :numbered}}]
   (script
-   (": ")
-   ("#" "-- START pallet implementation function")
-   (defn record_file [path state_path]
-     (chain-and
-      ;; output the diff between current and new
-      (var contentdiff "")
-      (if (&& (file-exists? @path) (file-exists? @state_path))
-        (do
-          (diff @path @state_path :unified true)
-          (set! contentdiff "$?")))
+   (group
+    ("#" "-- START pallet implementation function\n")
+    (defn record_file [path state_path]
+      (chain-and
+       ;; output the diff between current and new
+       (var contentdiff "")
+       (if (&& (file-exists? @path) (file-exists? @state_path))
+         (do
+           (diff @path @state_path :unified true)
+           (set! contentdiff "$?")))
 
-      ;; install the file if the content is different
-      (if (file-exists? @path)
-        (if (not (== @contentdiff 0))
-          (cp @path @state_path :force ~true :backup ~versioning)))
+       ;; install the file if the content is different
+       (if (file-exists? @path)
+         (if (not (== @contentdiff 0))
+           (cp @path @state_path :force ~true :backup ~versioning)))
 
-      ;; cleanup backup copies
-      ~(if (and (not no-versioning) (pos? max-versions))
-         (script
-          (pipe
-           ((ls (str @state_path ".~[0-9]*~") :sort-by-time ~true)
-            "2>" "/dev/null")
-           (tail "" :max-lines ~(str "+" (inc max-versions)))
-           (xargs (rm "" :force ~true))))
-         "")))
-   ("#" "-- END pallet implementation function")
-   ("record_file" ~path ~state-path )))
+       ;; cleanup backup copies
+       ~(if (and (not no-versioning) (pos? max-versions))
+          (script
+           (pipe
+            ((ls (str @state_path ".~[0-9]*~") :sort-by-time ~true)
+             "2>" "/dev/null")
+            (tail "" :max-lines ~(str "+" (inc max-versions)))
+            (xargs (rm "" :force ~true))))
+          "")))
+    ("#" "-- END pallet implementation function\n")
+    ("record_file" ~path ~state-path ))))
 
 (defn record-md5
   "Script to record a file's md5"
   [path md5-path]
   ;; write the md5 file
   (script
-   (": ")
-   ("#" "-- START pallet implementation function")
-   (defn record_md5 [path md5_path]
-     (chain-and
-      (file/write-md5-for-file @path @md5_path)
-      (println "MD5 sum is" @(cat @md5_path))))
-   ("#" "-- END pallet implementation function")
-   ("record_md5" ~path ~md5-path)))
+   (group
+    ("#" "-- START pallet implementation function\n")
+    (defn record_md5 [path md5_path]
+      (chain-and
+       (file/write-md5-for-file @path @md5_path)
+       (println "MD5 sum is" @(cat @md5_path))))
+    ("#" "-- END pallet implementation function\n")
+    ("record_md5" ~path ~md5-path))))
 
 (defrecord StateRootBackup [state-root]
   FileBackup

--- a/test/_init.clj
+++ b/test/_init.clj
@@ -3,13 +3,14 @@
   (:require
    [clojure.test :refer :all]
    [pallet.action :refer [with-action-options]]
-   [pallet.actions :refer [directory]]
+   [pallet.actions :refer [directory exec-checked-script]]
    [pallet.algo.fsmop :refer [failed?]]
    [pallet.api :refer [group-spec lift plan-fn]]
    [pallet.common.logging.logutils :refer [logging-threshold-fixture]]
    [pallet.core.api :refer [phase-errors]]
    [pallet.crate :refer [admin-user]]
-   [pallet.script.lib :refer [file state-root]]
+   [pallet.script.lib
+    :refer [chown file mkdir path-owner state-root user-home]]
    [pallet.stevedore :refer [fragment]]
    [pallet.test-utils :refer [make-localhost-compute]]))
 
@@ -20,10 +21,29 @@
         op (lift
             (group-spec "local")
             :phase (plan-fn
-                     (with-action-options {:script-prefix :sudo}
-                       (directory (fragment (file (state-root) "pallet"))
-                                  :owner (:username (admin-user))
-                                  :recursive false)))
+                    (with-action-options {:script-prefix :sudo
+                                          :script-env-fwd [:TMPDIR]}
+                      ;; (exec-checked-script
+                      ;;  (str "Ensure " (state-root) " exists")
+                      ;;  (if-not (directory? ~(state-root))
+                      ;;    (do
+                      ;;      (mkdir -p ~(state-root)))))
+                      (directory
+                       (fragment (file (state-root) "pallet")))
+                      (directory
+                       (fragment (file (state-root) "pallet"
+                                       (user-home ~(:username (admin-user)))))
+                       :owner (:username (admin-user))
+                       :recursive false)
+                      (exec-checked-script
+                       "Ensure TMPDIR"
+                       (if (&& (directory? @TMPDIR)
+                               (== @(path-owner @TMPDIR)
+                                   ~(:username (admin-user))))
+                         (do
+                           (set! tpath (file (state-root) "pallet" @TMPDIR))
+                           (mkdir @tpath :path true)
+                           (chown ~(:username (admin-user)) @tpath))))))
             :compute compute
             :async true)
         session @op]


### PR DESCRIPTION
Failures in chown when reflecting the permissions of the file system tree into
state-root were not being reported.
