### PR TITLE
Removed :delete :true from rsync defaults.

### DIFF
--- a/src/pallet/actions/direct/rsync.clj
+++ b/src/pallet/actions/direct/rsync.clj
@@ -24,7 +24,7 @@
 
 (defn default-options
   [session]
-  {:r true :delete true :copy-links true
+  {:r true :copy-links true
    :rsync-path (if-let [sudo-user (rsync-sudo-user session)]
                  (fragment ((sudo :no-prompt true :user ~sudo-user) "rsync"))
                  "rsync")


### PR DESCRIPTION
Addresses Issue https://github.com/pallet/pallet/issues/343. Commit makes rsync functions non-destructive by default.
