### PR TITLE
Fix os detection for CentOS 7

### DIFF
--- a/src/pallet/crate/os.clj
+++ b/src/pallet/crate/os.clj
@@ -37,7 +37,7 @@
    (when (file-exists? "/etc/redhat-release")
      (set! ID @(pipe ("cat" "/etc/redhat-release")
                      ("egrep" -o -e "'^[A-Za-z ]+release'")
-                     ("sed -e 's/ release//'")))
+                     ("sed -e 's/ .*//'")))
      (set! RELEASE @(pipe ("cat" "/etc/redhat-release")
                           ("sed" -e "'s/.*release//'")
                           ("sed" -e "'s/[^0-9.]//g'"))))

--- a/src/pallet/crate/os.clj
+++ b/src/pallet/crate/os.clj
@@ -53,6 +53,9 @@
      (set! RELEASE @(pipe ("cat" "/etc/mandrake-release")
                           ("sed" -e "'s/.*release //'")
                           ("sed" -e "'s/ .*//'"))))
+   (when (file-exists? "/etc/debian_version")
+     (set! ID "Debian")
+     (set! RELEASE @("cat /etc/debian_version")))
 
    (println "{")
    (println "  :id" (str "'\"'" @ID:-unknown "'\"'"))


### PR DESCRIPTION
Fixes https://github.com/pallet/pallet/issues/349

/etc/redhat-release on CentOS 7 contains something like
"CentOS Linux release 7.2.1511 (Core)"
