### PR TITLE
Fix RuntimeException on Clojure 1.8.0

### DIFF
--- a/profiles.clj
+++ b/profiles.clj
@@ -24,6 +24,7 @@
                  "doc" ["do" "codox," "marg"]}}
  :no-checkouts {:checkout-deps-shares ^:replace []} ; disable checkouts
  :clojure-1.5.0 {:dependencies [[org.clojure/clojure "1.5.0"]]}
+ :clojure-1.8.0 {:dependencies [[org.clojure/clojure "1.8.0"]]}
  :jclouds {:repositories
            {"sonatype"
             "https://oss.sonatype.org/content/repositories/releases/"}

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@ unprecedented level of customization."
                   :exclusions [com.palletops/pallet]]
                  [com.palletops/script-exec "0.4.2"]
                  [com.palletops/stevedore "0.8.0-beta.7"]
-                 [clj-ssh "0.5.7"]
+                 [clj-ssh "0.5.14"]
                  [enlive "1.0.1"
                   :exclusions [org.clojure/clojure]]
                  [pallet-fsmop "0.3.1"

--- a/src/pallet/core/api.clj
+++ b/src/pallet/core/api.clj
@@ -228,7 +228,7 @@
        (ex-info
         (format "Node :count not specified for group: %s" group)
         {:reason :target-count-not-specified
-         :group group}) (:group-name group)))
+         :group group})))
     {:actual existing-count :target target-count
      :delta (- target-count existing-count)}))
 


### PR DESCRIPTION
Clojure 1.8.0 checks arguments to `throw`, causing `pallet/core/api.clj`
to fail:

```
Caused by: java.lang.RuntimeException: Too many arguments to throw,
throw expects a single Throwable instance.
```

I removed the extra arg to `throw` and also upgraded `clj-ssh` dependency
to latest version (the older version was stepping into the same
RuntimeException).

Thanks
